### PR TITLE
Improve error logging and reporting

### DIFF
--- a/src/probes.ts
+++ b/src/probes.ts
@@ -2,6 +2,7 @@ import * as client from 'prom-client';
 import config from './config';
 import log from './util/log';
 import { GraphQLError } from 'graphql';
+import * as _ from 'lodash';
 
 const errors = new client.Counter({
     name: `${config.metrics.prefix}errors_total`,
@@ -10,7 +11,7 @@ const errors = new client.Counter({
 });
 
 const sublabels = ['Unknown', 'ResultWindowError', 'ElasticSearchError'];
-['Validation', 'System'].forEach(typeLabel => {
+['validation', 'system'].forEach(typeLabel => {
     sublabels.forEach(subLabel => errors.labels(typeLabel, subLabel).inc(0));
 });
 
@@ -19,7 +20,7 @@ function determineSubtype (error: GraphQLError) {
         return error.originalError.constructor.name;
     }
 
-    return 'unknown';
+    return _.get(error, 'constructor.name', 'unknown');
 }
 
 export function validationError (error: GraphQLError) {

--- a/src/resolvers/hosts/hosts.integration.ts
+++ b/src/resolvers/hosts/hosts.integration.ts
@@ -868,7 +868,7 @@ describe('hosts query', function () {
                 offset: -1
             });
 
-            expect(probes.validationError).toHaveBeenCalled()
+            expect(probes.validationError).toHaveBeenCalled();
         });
 
         test('log system error', async () => {
@@ -890,7 +890,7 @@ describe('hosts query', function () {
                 offset: 100000
             });
 
-            expect(probes.systemError).toHaveBeenCalled()
+            expect(probes.systemError).toHaveBeenCalled();
         });
     });
 });


### PR DESCRIPTION
~The goal of this PR is to add enough error logging that we can start enabling things in prod/beta. A more extensive solution will come in a future PR~

This is now the improvements to error handling to better track specific errors xjoin-search encounters day to day