### PR TITLE
RHCLOUD-5487 Can't filter hosts by tags with no namespace when datasource = xjoin

### DIFF
--- a/src/resolvers/hosts/format.ts
+++ b/src/resolvers/hosts/format.ts
@@ -1,0 +1,14 @@
+import {NAMESPACE_NULL_VALUE} from '../inputTag';
+
+export function formatTags (tags = []) {
+    return tags.map((tag: any) => {
+        if (tag.namespace === NAMESPACE_NULL_VALUE) {
+            return {
+                ...tag,
+                namespace: null
+            };
+        }
+
+        return tag;
+    });
+}

--- a/src/resolvers/hosts/hosts.integration.ts
+++ b/src/resolvers/hosts/hosts.integration.ts
@@ -486,6 +486,27 @@ describe('hosts query', function () {
                 expect(data).toMatchSnapshot();
             });
 
+            test('simple tag filter with explicit null namespace', async () => {
+                const headers = createHeaders('noNamespace', 'noNamespace');
+                const { data } = await runQuery(TAG_QUERY, {
+                    filter: {
+                        tag: {
+                            namespace: {eq: null},
+                            key: {eq: 'foo'},
+                            value: {eq: null}
+                        }
+                    }
+                }, headers);
+
+                data.hosts.data.should.have.length(1);
+                data.hosts.data[0].tags.data.should.have.length(1);
+                data.hosts.data[0].tags.data[0].should.eql({
+                    namespace: null,
+                    key: 'foo',
+                    value: null
+                });
+            });
+
             test('tag filter union', async () => {
                 const { data } = await runQuery(TAG_QUERY, {
                     filter: {

--- a/src/resolvers/hosts/index.ts
+++ b/src/resolvers/hosts/index.ts
@@ -14,6 +14,7 @@ import {
 import { FilterResolver } from '../common';
 import { filterTimestamp } from '../inputTimestamp';
 import { filterTag } from '../inputTag';
+import { formatTags } from './format';
 
 type HostFilterResolver = FilterResolver<HostFilter>;
 
@@ -153,7 +154,7 @@ export default async function hosts(parent: any, args: QueryHostsArgs, context: 
 
     const data = _.map(result.body.hits.hits, result => {
         const item = result._source;
-        const structuredTags = item.tags_structured || [];
+        const structuredTags = formatTags(item.tags_structured);
         item.tags = {
             meta: {
                 count: structuredTags.length,

--- a/test/hosts.json
+++ b/test/hosts.json
@@ -630,5 +630,28 @@
             "insights-client/bar/7",
             "insights-client/bar/8"
         ]
+    },
+    {
+        "id": "399886f1-fcb5-43d8-be70-f4bbdb02d4b0",
+        "account": "noNamespace",
+        "display_name": "bar",
+        "created_on": "2019-03-10T08:07:03.354307Z",
+        "modified_on": "2019-03-10T08:07:03.354312Z",
+        "stale_timestamp": "2030-03-10T08:07:03.354307Z",
+        "reporter": "puptoo",
+        "ansible_host": "foo.local",
+        "canonical_facts": {
+            "fqdn": "foo.local",
+            "insights_id": "295f1ac0-fcf4-4255-83cb-b0c779de3951"
+        },
+        "system_profile_facts": {},
+        "tags_structured": [{
+            "namespace": "null",
+            "key": "foo",
+            "value": null
+        }],
+        "tags_string": [
+            "null/foo"
+        ]
     }
 ]


### PR DESCRIPTION
Depends on https://github.com/RedHatInsights/xjoin-search/pull/59