### PR TITLE
RHCLOUD-5656 RHCLOUD-5691 RHCLOUD-5668 Do not use percent-encoded for…

### DIFF
--- a/docs/schema.md
+++ b/docs/schema.md
@@ -783,14 +783,10 @@ Defines the criteria by which tags are filtered in the `hostTags` query.
 <td>
 
 Limits the aggregation to tags that match the given search term.
-The search term is a regular exression that operates on percent-encoded tag namespace, key and value at the same time.
-In order to match the query regular expression needs to match percent-encoded strings.
-
-For example, to match tags with `Δwithčhars!` suffix the tag name query should look like:
-```
-{
-    name: ".*%CE%94with%C4%8Dhars%21"
-}
+The search term is a regular exression that operates on a string representation of a tag.
+The string representation has a form of "namespace/key=value" i.e. the segments are concatenated together using "=" and "/", respectively.
+There is no expecing of the control characters in the segments.
+As a result, "=" and "/" appear in every tag.
 ```
 
 </td>

--- a/src/generated/graphql.ts
+++ b/src/generated/graphql.ts
@@ -249,14 +249,11 @@ export type StructuredTag = {
 export type TagAggregationFilter = {
   /** 
  * Limits the aggregation to tags that match the given search term.
-   * The search term is a regular exression that operates on percent-encoded tag namespace, key and value at the same time.
-   * In order to match the query regular expression needs to match percent-encoded strings.
-   * 
-   * For example, to match tags with `Δwithčhars!` suffix the tag name query should look like:
-   * ```
-   * {
-   *     name: ".*%CE%94with%C4%8Dhars%21"
-   * }
+   * The search term is a regular exression that operates on a string representation of a tag.
+   * The string representation has a form of "namespace/key=value" i.e. the
+   * segments are concatenated together using "=" and "/", respectively.
+   * There is no expecing of the control characters in the segments.
+   * As a result, "=" and "/" appear in every tag.
    * ```
  */
   search?: Maybe<FilterStringWithRegex>;

--- a/src/schema/schema.graphql
+++ b/src/schema/schema.graphql
@@ -180,14 +180,10 @@ Defines the criteria by which tags are filtered in the `hostTags` query.
 input TagAggregationFilter {
     """
     Limits the aggregation to tags that match the given search term.
-    The search term is a regular exression that operates on percent-encoded tag namespace, key and value at the same time.
-    In order to match the query regular expression needs to match percent-encoded strings.
-
-    For example, to match tags with `Δwithčhars!` suffix the tag name query should look like:
-    ```
-    {
-        name: ".*%CE%94with%C4%8Dhars%21"
-    }
+    The search term is a regular exression that operates on a string representation of a tag.
+    The string representation has a form of "namespace/key=value" i.e. the segments are concatenated together using "=" and "/", respectively.
+    There is no expecing of the control characters in the segments.
+    As a result, "=" and "/" appear in every tag.
     ```
     """
     search: FilterStringWithRegex

--- a/test/hosts.json
+++ b/test/hosts.json
@@ -653,5 +653,57 @@
         "tags_string": [
             "null/foo"
         ]
+    },
+    {
+        "id": "bd37baad-ce97-4488-ba0c-fb93edd36f7f",
+        "account": "hostTagsSpecialChars",
+        "display_name": "foo",
+        "created_on": "2019-03-10T08:07:03.354307Z",
+        "modified_on": "2019-03-10T08:07:03.354312Z",
+        "stale_timestamp": "2030-03-10T08:07:03.354307Z",
+        "reporter": "puptoo",
+        "ansible_host": "foo.local",
+        "canonical_facts": {
+            "fqdn": "foo.local",
+            "insights_id": "d4d30804-93a5-463c-86d4-e639443fb5c5"
+        },
+        "system_profile_facts": {},
+        "tags_structured": [{
+            "namespace": "insights-client",
+            "key": "os",
+            "value": "fedora"
+        }]
+    },
+    {
+        "id": "b72cf877-3433-4755-b172-65700a56545a",
+        "account": "hostTagsSpecialChars",
+        "display_name": "bar",
+        "created_on": "2019-03-10T08:07:03.354307Z",
+        "modified_on": "2019-03-10T08:07:03.354312Z",
+        "stale_timestamp": "2030-03-10T08:07:03.354307Z",
+        "reporter": "puptoo",
+        "ansible_host": "bar.local",
+        "canonical_facts": {
+            "fqdn": "bar.local",
+            "insights_id": "67d876f0-2e8e-45fc-becb-bc40cf1f92b2"
+        },
+        "system_profile_facts": {},
+        "tags_structured": [{
+            "namespace": "insights-client",
+            "key": "os",
+            "value": "fedora"
+        }, {
+            "namespace": "insights-client",
+            "key": "keyΔwithčhars*+!.,-_ ",
+            "value": "value"
+        }, {
+            "namespace": "insights-client",
+            "key": "key",
+            "value": "keyΔwithčhars*+!.,-_ "
+        }, {
+            "namespace": "keyΔwithčhars*+!.,-_ ",
+            "key": "key",
+            "value": "value"
+        }]
     }
 ]


### PR DESCRIPTION
…mat of a tag for searching

Instead, index each tags in a string for of "<namespace>/<key>=<value>".
This makes the control characters (/=) indistinguishable when used in the key or value but it's what we're asked to do