### PR TITLE
Add ingest timestamp [RHCLOUD-4614]

### DIFF
--- a/test/seed.js
+++ b/test/seed.js
@@ -20,6 +20,10 @@ async function run () {
         body: {
             description: 'Ingest pipeline for xjoin.inventory.hosts',
             processors: [{
+                set: {
+                    field: "ingest_timestamp",
+                    value: "{{_ingest.timestamp}}"
+                },
                 script: {
                     lang: 'painless',
                     if: 'ctx.tags_structured != null',
@@ -52,6 +56,7 @@ async function run () {
         body: {
             dynamic: false,
             properties: {
+                ingest_timestamp: {type: 'date'},
                 id: { type: 'keyword' },
                 account: { type: 'keyword' },
                 display_name: {


### PR DESCRIPTION
We want to be able to calculate the lag time between host creation and ingestion. This PR adds a field that records the ingest_timestamp to make it possible.

[Link to Jira](https://projects.engineering.redhat.com/browse/RHCLOUD-4614)