### PR TITLE
fix: update dockerfile for security fixes

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -10,14 +10,6 @@ COPY . /opt/app-root/src
 
 RUN npm i typescript@3.6.3 && npm run compile
 
-USER root
-
-RUN UPDATE_PKGS="kernel-headers binutils" && \
-    yum update -y $UPDATE_PKGS && \
-    yum clean all
-
-USER 1001
-
 EXPOSE 4000
 ENV NODE_ENV=production
 CMD [ "node", "dist/src/app.js" ]


### PR DESCRIPTION
It looks like the rhoar-nodejs image **may** not be the most up to date
option for nodejs-10 these days. I built this with the image I"ve added
here and it seems to work. Also added a yum update for packages that
routinely seem to cause security vulns to fire.

Signed-off-by: Stephen Adams <tsadams@gmail.com>