### PR TITLE
made fqdn use lowercase operations

### DIFF
--- a/docs/schema.md
+++ b/docs/schema.md
@@ -1065,7 +1065,7 @@ Filter by display_name
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>fqdn</strong></td>
-<td valign="top"><a href="#filterstringwithwildcard">FilterStringWithWildcard</a></td>
+<td valign="top"><a href="#filterstringwithwildcardwithlowercase">FilterStringWithWildcardWithLowercase</a></td>
 <td>
 
 Filter by fqdn

--- a/src/generated/graphql.ts
+++ b/src/generated/graphql.ts
@@ -222,7 +222,7 @@ export type HostFilter = {
   /** Filter by display_name */
   display_name?: Maybe<FilterStringWithWildcardWithLowercase>;
   /** Filter by fqdn */
-  fqdn?: Maybe<FilterStringWithWildcard>;
+  fqdn?: Maybe<FilterStringWithWildcardWithLowercase>;
   /** Filter by provider_type */
   provider_type?: Maybe<FilterString>;
   /** Filter by provider_id */

--- a/src/resolvers/hosts/index.ts
+++ b/src/resolvers/hosts/index.ts
@@ -56,7 +56,7 @@ const RESOLVERS: HostFilterResolver[] = [
         filter.insights_id, _.partial(filterStringWithWildcard, 'canonical_facts.insights_id')),
     optional((filter: HostFilter) =>
         filter.display_name, _.partial(filterStringWithWildcardWithLowercase, 'display_name')),
-    optional((filter: HostFilter) => filter.fqdn, _.partial(filterStringWithWildcard, 'canonical_facts.fqdn')),
+    optional((filter: HostFilter) => filter.fqdn, _.partial(filterStringWithWildcardWithLowercase, 'canonical_facts.fqdn')),
     optional((filter: HostFilter) => filter.provider_type, _.partial(filterString, 'canonical_facts.provider_type')),
     optional((filter: HostFilter) => filter.provider_id, _.partial(filterString, 'canonical_facts.provider_id')),
 

--- a/src/schema/schema.graphql
+++ b/src/schema/schema.graphql
@@ -54,7 +54,7 @@ input HostFilter {
     "Filter by display_name"
     display_name: FilterStringWithWildcardWithLowercase,
     "Filter by fqdn"
-    fqdn: FilterStringWithWildcard,
+    fqdn: FilterStringWithWildcardWithLowercase,
     "Filter by provider_type"
     provider_type: FilterString,
     "Filter by provider_id"


### PR DESCRIPTION
On HBI we switched over to querying for fqdn in lowecase prematurely, we are getting lots of 400 errors from xjoin-search because of this. This PR will fix that by switching fqdn to using all lowercase operations.

refer the the PR that introduced the bug here for the reasoning behind the change: https://github.com/RedHatInsights/insights-host-inventory/pull/956