### PR TITLE
[WIP] Make tag search case-insensitive

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1784,7 +1784,7 @@
         "sync-fetch": "0.3.0",
         "tslib": "~2.2.0",
         "valid-url": "1.0.9",
-        "ws": "7.4.5"
+        "ws": "7.4.6"
       },
       "dependencies": {
         "form-data": {
@@ -7670,7 +7670,7 @@
         "whatwg-encoding": "^1.0.5",
         "whatwg-mimetype": "^2.3.0",
         "whatwg-url": "^8.5.0",
-        "ws": "^7.4.5",
+        "ws": "7.4.6",
         "xml-name-validator": "^3.0.0"
       },
       "dependencies": {
@@ -10208,7 +10208,7 @@
         "eventemitter3": "^3.1.0",
         "iterall": "^1.2.1",
         "symbol-observable": "^1.0.4",
-        "ws": "^5.2.0 || ^6.0.0 || ^7.0.0"
+        "ws": "7.4.6"
       },
       "dependencies": {
         "ws": {
@@ -11083,9 +11083,9 @@
       }
     },
     "ws": {
-      "version": "7.5.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.3.tgz",
-      "integrity": "sha512-kQ/dHIzuLrS6Je9+uv81ueZomEwH0qVYstcAQ4/Z93K8zeko9gtAbttJWzoC5ukqXY1PpoouV3+VSOqEAFt5wg==",
+      "version": "7.4.6",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
+      "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
       "dev": true
     },
     "xml-name-validator": {

--- a/src/resolvers/inputTag.ts
+++ b/src/resolvers/inputTag.ts
@@ -14,7 +14,7 @@ function getFilterStringValue (value: FilterString | undefined | null, dflt = ES
         return dflt;
     }
 
-    return value.eq;
+    return value.eq.toLowerCase();
 }
 
 export function filterTag (value: FilterTag): Record<string, any>[] {


### PR DESCRIPTION
This makes tag searches case-insensitve but using wild card for tag search does not work. 

@ryandillinfelton This looks too simple.  For now this is how I have been able to make it work.  Using `value.eg_lc` on `FilterStringWithWildcardWithLowercase` did not work.  The error to be provided.