### PR TITLE
[WIP] ignore case for filtering/searching tags

### DIFF
--- a/docs/schema.md
+++ b/docs/schema.md
@@ -916,7 +916,7 @@ Filters hosts by the presence of a host tag
 <tbody>
 <tr>
 <td colspan="2" valign="top"><strong>namespace</strong></td>
-<td valign="top"><a href="#filterstring">FilterString</a></td>
+<td valign="top"><a href="#filterstringwithwildcardwithlowercase">FilterStringWithWildcardWithLowercase</a></td>
 <td>
 
 Tag namespace
@@ -925,7 +925,7 @@ Tag namespace
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>key</strong></td>
-<td valign="top"><a href="#filterstring">FilterString</a>!</td>
+<td valign="top"><a href="#filterstringwithwildcardwithlowercase">FilterStringWithWildcardWithLowercase</a>!</td>
 <td>
 
 Tag key
@@ -934,7 +934,7 @@ Tag key
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>value</strong></td>
-<td valign="top"><a href="#filterstring">FilterString</a></td>
+<td valign="top"><a href="#filterstringwithwildcardwithlowercase">FilterStringWithWildcardWithLowercase</a></td>
 <td>
 
 Tag value

--- a/package-lock.json
+++ b/package-lock.json
@@ -1784,7 +1784,7 @@
         "sync-fetch": "0.3.0",
         "tslib": "~2.2.0",
         "valid-url": "1.0.9",
-        "ws": "7.4.5"
+        "ws": "7.4.6"
       },
       "dependencies": {
         "form-data": {
@@ -7670,7 +7670,7 @@
         "whatwg-encoding": "^1.0.5",
         "whatwg-mimetype": "^2.3.0",
         "whatwg-url": "^8.5.0",
-        "ws": "^7.4.5",
+        "ws": "7.4.6",
         "xml-name-validator": "^3.0.0"
       },
       "dependencies": {
@@ -10208,7 +10208,7 @@
         "eventemitter3": "^3.1.0",
         "iterall": "^1.2.1",
         "symbol-observable": "^1.0.4",
-        "ws": "^5.2.0 || ^6.0.0 || ^7.0.0"
+        "ws": "7.4.6"
       },
       "dependencies": {
         "ws": {
@@ -11083,9 +11083,9 @@
       }
     },
     "ws": {
-      "version": "7.5.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.3.tgz",
-      "integrity": "sha512-kQ/dHIzuLrS6Je9+uv81ueZomEwH0qVYstcAQ4/Z93K8zeko9gtAbttJWzoC5ukqXY1PpoouV3+VSOqEAFt5wg==",
+      "version": "7.4.6",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
+      "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
       "dev": true
     },
     "xml-name-validator": {

--- a/src/generated/graphql.ts
+++ b/src/generated/graphql.ts
@@ -140,11 +140,11 @@ export type FilterStringWithWildcardWithLowercase = {
 /** Filters hosts by the presence of a host tag */
 export type FilterTag = {
   /** Tag namespace */
-  namespace?: Maybe<FilterString>;
+  namespace?: Maybe<FilterStringWithWildcardWithLowercase>;
   /** Tag key */
-  key: FilterString;
+  key: FilterStringWithWildcardWithLowercase;
   /** Tag value */
-  value?: Maybe<FilterString>;
+  value?: Maybe<FilterStringWithWildcardWithLowercase>;
 };
 
 /** Timestamp field filter with support for common operations. */

--- a/src/resolvers/hosts/__snapshots__/hosts.integration.ts.snap
+++ b/src/resolvers/hosts/__snapshots__/hosts.integration.ts.snap
@@ -645,6 +645,41 @@ Object {
 }
 `;
 
+exports[`hosts query queries tags simple tag filter with case-insenstive value 1`] = `
+Object {
+  "hosts": Object {
+    "data": Array [
+      Object {
+        "display_name": "test01.rhel7.jharting.local",
+        "id": "6e7b6317-0a2d-4552-a2f2-b7da0aece49d",
+        "tags": Object {
+          "data": Array [
+            Object {
+              "key": "env",
+              "namespace": "Sat",
+              "value": "prod",
+            },
+            Object {
+              "key": "region",
+              "namespace": "aws",
+              "value": "us-east-1",
+            },
+            Object {
+              "key": "database",
+              "namespace": "insights-client",
+              "value": null,
+            },
+          ],
+          "meta": Object {
+            "total": 3,
+          },
+        },
+      },
+    ],
+  },
+}
+`;
+
 exports[`hosts query queries tags simple tag filter with explicit null value 1`] = `
 Object {
   "hosts": Object {
@@ -736,6 +771,41 @@ Object {
 `;
 
 exports[`hosts query queries tags simple tag filter with value 1`] = `
+Object {
+  "hosts": Object {
+    "data": Array [
+      Object {
+        "display_name": "test01.rhel7.jharting.local",
+        "id": "6e7b6317-0a2d-4552-a2f2-b7da0aece49d",
+        "tags": Object {
+          "data": Array [
+            Object {
+              "key": "env",
+              "namespace": "Sat",
+              "value": "prod",
+            },
+            Object {
+              "key": "region",
+              "namespace": "aws",
+              "value": "us-east-1",
+            },
+            Object {
+              "key": "database",
+              "namespace": "insights-client",
+              "value": null,
+            },
+          ],
+          "meta": Object {
+            "total": 3,
+          },
+        },
+      },
+    ],
+  },
+}
+`;
+
+exports[`hosts query queries tags simple tag filter with wildcard key value 1`] = `
 Object {
   "hosts": Object {
     "data": Array [

--- a/src/resolvers/hosts/hosts.integration.ts
+++ b/src/resolvers/hosts/hosts.integration.ts
@@ -739,6 +739,32 @@ describe('hosts query', function () {
                 });
             });
 
+            test('simple tag filter with case-insenstive value', async () => {
+                const { data } = await runQuery(TAG_QUERY, {
+                    filter: {
+                        tag: {
+                            namespace: {eq: 'AWS'},
+                            key: {eq: 'REGION'},
+                            value: {eq: 'US-EAST-1'}
+                        }
+                    }
+                });
+                expect(data).toMatchSnapshot();
+            });
+
+            test('simple tag filter with wildcard key value', async () => {
+                const { data } = await runQuery(TAG_QUERY, {
+                    filter: {
+                        tag: {
+                            namespace: {eq: 'aws'},
+                            key: {eq: '*'},
+                            value: {eq: 'us-*-1'}
+                        }
+                    }
+                });
+                expect(data).toMatchSnapshot();
+            });
+
             test('tag filter union', async () => {
                 const { data } = await runQuery(TAG_QUERY, {
                     filter: {

--- a/src/resolvers/inputTag.ts
+++ b/src/resolvers/inputTag.ts
@@ -24,11 +24,11 @@ export function filterTag (value: FilterTag): Record<string, any>[] {
             query: {
                 bool: {
                     filter: [{
-                        term: { 'tags_structured.namespace': getFilterStringValue(value.namespace, NAMESPACE_NULL_VALUE) }
+                        wildcard: { 'tags_structured.namespace': getFilterStringValue(value.namespace, NAMESPACE_NULL_VALUE) }
                     }, {
-                        term: { 'tags_structured.key': getFilterStringValue(value.key) }
+                        wildcard: { 'tags_structured.key': getFilterStringValue(value.key) }
                     }, {
-                        term: { 'tags_structured.value': getFilterStringValue(value.value) }
+                        wildcard: { 'tags_structured.value': getFilterStringValue(value.value) }
                     }]
                 }
             }

--- a/src/resolvers/inputTag.ts
+++ b/src/resolvers/inputTag.ts
@@ -14,7 +14,7 @@ function getFilterStringValue (value: FilterString | undefined | null, dflt = ES
         return dflt;
     }
 
-    return value.eq;
+    return value.eq.toLowerCase();
 }
 
 export function filterTag (value: FilterTag): Record<string, any>[] {

--- a/src/resolvers/inputTag.ts
+++ b/src/resolvers/inputTag.ts
@@ -1,4 +1,4 @@
-import { FilterTag, FilterString } from '../generated/graphql';
+import { FilterTag, FilterStringWithWildcardWithLowercase } from '../generated/graphql';
 import {ES_NULL_VALUE} from '../constants';
 
 /*
@@ -9,7 +9,7 @@ import {ES_NULL_VALUE} from '../constants';
  */
 export const NAMESPACE_NULL_VALUE = 'null';
 
-function getFilterStringValue (value: FilterString | undefined | null, dflt = ES_NULL_VALUE): string {
+function getFilterStringValue (value: FilterStringWithWildcardWithLowercase | undefined | null, dflt = ES_NULL_VALUE): string {
     if (!value || !value.eq) {
         return dflt;
     }

--- a/src/schema/schema.graphql
+++ b/src/schema/schema.graphql
@@ -210,13 +210,13 @@ Filters hosts by the presence of a host tag
 """
 input FilterTag {
     "Tag namespace"
-    namespace: FilterString,
+    namespace: FilterStringWithWildcardWithLowercase,
 
     "Tag key"
-    key: FilterString!,
+    key: FilterStringWithWildcardWithLowercase!,
 
     "Tag value"
-    value: FilterString
+    value: FilterStringWithWildcardWithLowercase
 }
 
 """


### PR DESCRIPTION
@ryandillinfelton Here is how I could make tag search/filter work with `ignore-case` but using `insights-*` for `insights-client` does not work.   

Using `value.eq_lc` also does not work because vscode would complain with:
`Type 'Maybe<string> | undefined' is not assignable to type 'string'.  Type 'undefined' is not assignable to type 'string'.ts(2322)`

