### PR TITLE
Fix operating_system ordering script

### DIFF
--- a/src/resolvers/hosts/__snapshots__/hosts.integration.ts.snap
+++ b/src/resolvers/hosts/__snapshots__/hosts.integration.ts.snap
@@ -151,6 +151,42 @@ Object {
         "reporter": "puptoo",
         "stale_timestamp": "2030-03-10T08:07:03.354307Z",
       },
+      Object {
+        "account": "test",
+        "ansible_host": "test01.rhel7.aprice.local",
+        "display_name": "test1.rhel7.aprice.local",
+        "id": "f5ac67e1-ad65-4b62-bc27-845cc6d4bc01",
+        "modified_on": "2019-03-10T08:07:03.354312Z",
+        "reporter": "puptoo",
+        "stale_timestamp": "2030-03-10T08:07:03.354307Z",
+      },
+      Object {
+        "account": "test",
+        "ansible_host": "test02.rhel7.aprice.local",
+        "display_name": "test2.rhel7.aprice.local",
+        "id": "f5ac67e1-ad65-4b62-bc27-845cc6d4bc02",
+        "modified_on": "2019-03-10T08:07:03.354312Z",
+        "reporter": "puptoo",
+        "stale_timestamp": "2030-03-10T08:07:03.354307Z",
+      },
+      Object {
+        "account": "test",
+        "ansible_host": "test03.rhel8.aprice.local",
+        "display_name": "test3.rhel8.aprice.local",
+        "id": "f5ac67e1-ad65-4b62-bc27-845cc6d4bc03",
+        "modified_on": "2019-03-10T08:07:03.354312Z",
+        "reporter": "puptoo",
+        "stale_timestamp": "2030-03-10T08:07:03.354307Z",
+      },
+      Object {
+        "account": "test",
+        "ansible_host": "test04.rhel.aprice.local",
+        "display_name": "test4.rhel.aprice.local",
+        "id": "f5ac67e1-ad65-4b62-bc27-845cc6d4bc04",
+        "modified_on": "2019-03-10T08:07:03.354312Z",
+        "reporter": "puptoo",
+        "stale_timestamp": "2030-03-10T08:07:03.354307Z",
+      },
     ],
   },
 }
@@ -187,6 +223,42 @@ Object {
         "reporter": "puptoo",
         "stale_timestamp": "2030-03-10T08:07:03.354307Z",
       },
+      Object {
+        "account": "test",
+        "ansible_host": "test01.rhel7.aprice.local",
+        "display_name": "test1.rhel7.aprice.local",
+        "id": "f5ac67e1-ad65-4b62-bc27-845cc6d4bc01",
+        "modified_on": "2019-03-10T08:07:03.354312Z",
+        "reporter": "puptoo",
+        "stale_timestamp": "2030-03-10T08:07:03.354307Z",
+      },
+      Object {
+        "account": "test",
+        "ansible_host": "test02.rhel7.aprice.local",
+        "display_name": "test2.rhel7.aprice.local",
+        "id": "f5ac67e1-ad65-4b62-bc27-845cc6d4bc02",
+        "modified_on": "2019-03-10T08:07:03.354312Z",
+        "reporter": "puptoo",
+        "stale_timestamp": "2030-03-10T08:07:03.354307Z",
+      },
+      Object {
+        "account": "test",
+        "ansible_host": "test03.rhel8.aprice.local",
+        "display_name": "test3.rhel8.aprice.local",
+        "id": "f5ac67e1-ad65-4b62-bc27-845cc6d4bc03",
+        "modified_on": "2019-03-10T08:07:03.354312Z",
+        "reporter": "puptoo",
+        "stale_timestamp": "2030-03-10T08:07:03.354307Z",
+      },
+      Object {
+        "account": "test",
+        "ansible_host": "test04.rhel.aprice.local",
+        "display_name": "test4.rhel.aprice.local",
+        "id": "f5ac67e1-ad65-4b62-bc27-845cc6d4bc04",
+        "modified_on": "2019-03-10T08:07:03.354312Z",
+        "reporter": "puptoo",
+        "stale_timestamp": "2030-03-10T08:07:03.354307Z",
+      },
     ],
   },
 }
@@ -196,6 +268,42 @@ exports[`hosts query ordering display_name DESC 1`] = `
 Object {
   "hosts": Object {
     "data": Array [
+      Object {
+        "account": "test",
+        "ansible_host": "test04.rhel.aprice.local",
+        "display_name": "test4.rhel.aprice.local",
+        "id": "f5ac67e1-ad65-4b62-bc27-845cc6d4bc04",
+        "modified_on": "2019-03-10T08:07:03.354312Z",
+        "reporter": "puptoo",
+        "stale_timestamp": "2030-03-10T08:07:03.354307Z",
+      },
+      Object {
+        "account": "test",
+        "ansible_host": "test03.rhel8.aprice.local",
+        "display_name": "test3.rhel8.aprice.local",
+        "id": "f5ac67e1-ad65-4b62-bc27-845cc6d4bc03",
+        "modified_on": "2019-03-10T08:07:03.354312Z",
+        "reporter": "puptoo",
+        "stale_timestamp": "2030-03-10T08:07:03.354307Z",
+      },
+      Object {
+        "account": "test",
+        "ansible_host": "test02.rhel7.aprice.local",
+        "display_name": "test2.rhel7.aprice.local",
+        "id": "f5ac67e1-ad65-4b62-bc27-845cc6d4bc02",
+        "modified_on": "2019-03-10T08:07:03.354312Z",
+        "reporter": "puptoo",
+        "stale_timestamp": "2030-03-10T08:07:03.354307Z",
+      },
+      Object {
+        "account": "test",
+        "ansible_host": "test01.rhel7.aprice.local",
+        "display_name": "test1.rhel7.aprice.local",
+        "id": "f5ac67e1-ad65-4b62-bc27-845cc6d4bc01",
+        "modified_on": "2019-03-10T08:07:03.354312Z",
+        "reporter": "puptoo",
+        "stale_timestamp": "2030-03-10T08:07:03.354307Z",
+      },
       Object {
         "account": "test",
         "ansible_host": "test03.rhel7.jharting.local",
@@ -234,6 +342,42 @@ Object {
     "data": Array [
       Object {
         "account": "test",
+        "ansible_host": "test01.rhel7.aprice.local",
+        "display_name": "test1.rhel7.aprice.local",
+        "id": "f5ac67e1-ad65-4b62-bc27-845cc6d4bc01",
+        "modified_on": "2019-03-10T08:07:03.354312Z",
+        "reporter": "puptoo",
+        "stale_timestamp": "2030-03-10T08:07:03.354307Z",
+      },
+      Object {
+        "account": "test",
+        "ansible_host": "test02.rhel7.aprice.local",
+        "display_name": "test2.rhel7.aprice.local",
+        "id": "f5ac67e1-ad65-4b62-bc27-845cc6d4bc02",
+        "modified_on": "2019-03-10T08:07:03.354312Z",
+        "reporter": "puptoo",
+        "stale_timestamp": "2030-03-10T08:07:03.354307Z",
+      },
+      Object {
+        "account": "test",
+        "ansible_host": "test03.rhel8.aprice.local",
+        "display_name": "test3.rhel8.aprice.local",
+        "id": "f5ac67e1-ad65-4b62-bc27-845cc6d4bc03",
+        "modified_on": "2019-03-10T08:07:03.354312Z",
+        "reporter": "puptoo",
+        "stale_timestamp": "2030-03-10T08:07:03.354307Z",
+      },
+      Object {
+        "account": "test",
+        "ansible_host": "test04.rhel.aprice.local",
+        "display_name": "test4.rhel.aprice.local",
+        "id": "f5ac67e1-ad65-4b62-bc27-845cc6d4bc04",
+        "modified_on": "2019-03-10T08:07:03.354312Z",
+        "reporter": "puptoo",
+        "stale_timestamp": "2030-03-10T08:07:03.354307Z",
+      },
+      Object {
+        "account": "test",
         "ansible_host": "test03.rhel7.jharting.local",
         "display_name": "test03.rhel7.jharting.local",
         "id": "f5ac67e1-ad65-4b62-bc27-845cc6d4bcee",
@@ -270,6 +414,17 @@ Object {
     "data": Array [
       Object {
         "account": "test",
+        "display_name": "test2.rhel7.aprice.local",
+        "id": "f5ac67e1-ad65-4b62-bc27-845cc6d4bc02",
+        "system_profile_facts": Object {
+          "operating_system": Object {
+            "major": 8,
+          },
+          "owner_id": "it8i99u1-48ut-1rdf-bc10-84opf904test",
+        },
+      },
+      Object {
+        "account": "test",
         "display_name": "test03.rhel7.jharting.local",
         "id": "f5ac67e1-ad65-4b62-bc27-845cc6d4bcee",
         "system_profile_facts": Object {
@@ -304,6 +459,29 @@ Object {
           "rhc_client_id": "22cd8e39-13bb-4d02-8316-84b850dc5136",
           "satellite_managed": false,
           "system_memory_bytes": 511451136,
+        },
+      },
+      Object {
+        "account": "test",
+        "display_name": "test1.rhel7.aprice.local",
+        "id": "f5ac67e1-ad65-4b62-bc27-845cc6d4bc01",
+        "system_profile_facts": Object {
+          "operating_system": Object {
+            "name": "RHEL",
+          },
+          "owner_id": "it8i99u1-48ut-1rdf-bc10-84opf904test",
+        },
+      },
+      Object {
+        "account": "test",
+        "display_name": "test4.rhel.aprice.local",
+        "id": "f5ac67e1-ad65-4b62-bc27-845cc6d4bc04",
+        "system_profile_facts": Object {
+          "operating_system": Object {
+            "minor": 7,
+            "name": "RHEL",
+          },
+          "owner_id": "it8i99u1-48ut-1rdf-bc10-84opf904test",
         },
       },
       Object {
@@ -375,6 +553,18 @@ Object {
           "rhc_client_id": "33cd8e39-13bb-4d02-8316-84b850dc5136",
           "satellite_managed": false,
           "system_memory_bytes": 511451136,
+        },
+      },
+      Object {
+        "account": "test",
+        "display_name": "test3.rhel8.aprice.local",
+        "id": "f5ac67e1-ad65-4b62-bc27-845cc6d4bc03",
+        "system_profile_facts": Object {
+          "operating_system": Object {
+            "major": 8,
+            "name": "RHEL",
+          },
+          "owner_id": "it8i99u1-48ut-1rdf-bc10-84opf904test",
         },
       },
     ],
@@ -388,6 +578,18 @@ Object {
     "data": Array [
       Object {
         "account": "test",
+        "display_name": "test3.rhel8.aprice.local",
+        "id": "f5ac67e1-ad65-4b62-bc27-845cc6d4bc03",
+        "system_profile_facts": Object {
+          "operating_system": Object {
+            "major": 8,
+            "name": "RHEL",
+          },
+          "owner_id": "it8i99u1-48ut-1rdf-bc10-84opf904test",
+        },
+      },
+      Object {
+        "account": "test",
         "display_name": "test01.rhel7.jharting.local",
         "id": "6e7b6317-0a2d-4552-a2f2-b7da0aece49d",
         "system_profile_facts": Object {
@@ -459,6 +661,29 @@ Object {
       },
       Object {
         "account": "test",
+        "display_name": "test4.rhel.aprice.local",
+        "id": "f5ac67e1-ad65-4b62-bc27-845cc6d4bc04",
+        "system_profile_facts": Object {
+          "operating_system": Object {
+            "minor": 7,
+            "name": "RHEL",
+          },
+          "owner_id": "it8i99u1-48ut-1rdf-bc10-84opf904test",
+        },
+      },
+      Object {
+        "account": "test",
+        "display_name": "test1.rhel7.aprice.local",
+        "id": "f5ac67e1-ad65-4b62-bc27-845cc6d4bc01",
+        "system_profile_facts": Object {
+          "operating_system": Object {
+            "name": "RHEL",
+          },
+          "owner_id": "it8i99u1-48ut-1rdf-bc10-84opf904test",
+        },
+      },
+      Object {
+        "account": "test",
         "display_name": "test03.rhel7.jharting.local",
         "id": "f5ac67e1-ad65-4b62-bc27-845cc6d4bcee",
         "system_profile_facts": Object {
@@ -493,6 +718,17 @@ Object {
           "rhc_client_id": "22cd8e39-13bb-4d02-8316-84b850dc5136",
           "satellite_managed": false,
           "system_memory_bytes": 511451136,
+        },
+      },
+      Object {
+        "account": "test",
+        "display_name": "test2.rhel7.aprice.local",
+        "id": "f5ac67e1-ad65-4b62-bc27-845cc6d4bc02",
+        "system_profile_facts": Object {
+          "operating_system": Object {
+            "major": 8,
+          },
+          "owner_id": "it8i99u1-48ut-1rdf-bc10-84opf904test",
         },
       },
     ],
@@ -627,6 +863,42 @@ Object {
         "reporter": "puptoo",
         "stale_timestamp": "2030-03-10T08:07:03.354307Z",
       },
+      Object {
+        "account": "test",
+        "ansible_host": "test01.rhel7.aprice.local",
+        "display_name": "test1.rhel7.aprice.local",
+        "id": "f5ac67e1-ad65-4b62-bc27-845cc6d4bc01",
+        "modified_on": "2019-03-10T08:07:03.354312Z",
+        "reporter": "puptoo",
+        "stale_timestamp": "2030-03-10T08:07:03.354307Z",
+      },
+      Object {
+        "account": "test",
+        "ansible_host": "test02.rhel7.aprice.local",
+        "display_name": "test2.rhel7.aprice.local",
+        "id": "f5ac67e1-ad65-4b62-bc27-845cc6d4bc02",
+        "modified_on": "2019-03-10T08:07:03.354312Z",
+        "reporter": "puptoo",
+        "stale_timestamp": "2030-03-10T08:07:03.354307Z",
+      },
+      Object {
+        "account": "test",
+        "ansible_host": "test03.rhel8.aprice.local",
+        "display_name": "test3.rhel8.aprice.local",
+        "id": "f5ac67e1-ad65-4b62-bc27-845cc6d4bc03",
+        "modified_on": "2019-03-10T08:07:03.354312Z",
+        "reporter": "puptoo",
+        "stale_timestamp": "2030-03-10T08:07:03.354307Z",
+      },
+      Object {
+        "account": "test",
+        "ansible_host": "test04.rhel.aprice.local",
+        "display_name": "test4.rhel.aprice.local",
+        "id": "f5ac67e1-ad65-4b62-bc27-845cc6d4bc04",
+        "modified_on": "2019-03-10T08:07:03.354312Z",
+        "reporter": "puptoo",
+        "stale_timestamp": "2030-03-10T08:07:03.354307Z",
+      },
     ],
   },
 }
@@ -650,6 +922,42 @@ Object {
         "ansible_host": "test03.rhel7.jharting.local",
         "display_name": "test03.rhel7.jharting.local",
         "id": "f5ac67e1-ad65-4b62-bc27-845cc6d4bcee",
+        "modified_on": "2019-03-10T08:07:03.354312Z",
+        "reporter": "puptoo",
+        "stale_timestamp": "2030-03-10T08:07:03.354307Z",
+      },
+      Object {
+        "account": "test",
+        "ansible_host": "test01.rhel7.aprice.local",
+        "display_name": "test1.rhel7.aprice.local",
+        "id": "f5ac67e1-ad65-4b62-bc27-845cc6d4bc01",
+        "modified_on": "2019-03-10T08:07:03.354312Z",
+        "reporter": "puptoo",
+        "stale_timestamp": "2030-03-10T08:07:03.354307Z",
+      },
+      Object {
+        "account": "test",
+        "ansible_host": "test02.rhel7.aprice.local",
+        "display_name": "test2.rhel7.aprice.local",
+        "id": "f5ac67e1-ad65-4b62-bc27-845cc6d4bc02",
+        "modified_on": "2019-03-10T08:07:03.354312Z",
+        "reporter": "puptoo",
+        "stale_timestamp": "2030-03-10T08:07:03.354307Z",
+      },
+      Object {
+        "account": "test",
+        "ansible_host": "test03.rhel8.aprice.local",
+        "display_name": "test3.rhel8.aprice.local",
+        "id": "f5ac67e1-ad65-4b62-bc27-845cc6d4bc03",
+        "modified_on": "2019-03-10T08:07:03.354312Z",
+        "reporter": "puptoo",
+        "stale_timestamp": "2030-03-10T08:07:03.354307Z",
+      },
+      Object {
+        "account": "test",
+        "ansible_host": "test04.rhel.aprice.local",
+        "display_name": "test4.rhel.aprice.local",
+        "id": "f5ac67e1-ad65-4b62-bc27-845cc6d4bc04",
         "modified_on": "2019-03-10T08:07:03.354312Z",
         "reporter": "puptoo",
         "stale_timestamp": "2030-03-10T08:07:03.354307Z",
@@ -879,6 +1187,46 @@ Object {
           ],
           "meta": Object {
             "total": 4,
+          },
+        },
+      },
+      Object {
+        "display_name": "test1.rhel7.aprice.local",
+        "id": "f5ac67e1-ad65-4b62-bc27-845cc6d4bc01",
+        "tags": Object {
+          "data": Array [],
+          "meta": Object {
+            "total": 0,
+          },
+        },
+      },
+      Object {
+        "display_name": "test2.rhel7.aprice.local",
+        "id": "f5ac67e1-ad65-4b62-bc27-845cc6d4bc02",
+        "tags": Object {
+          "data": Array [],
+          "meta": Object {
+            "total": 0,
+          },
+        },
+      },
+      Object {
+        "display_name": "test3.rhel8.aprice.local",
+        "id": "f5ac67e1-ad65-4b62-bc27-845cc6d4bc03",
+        "tags": Object {
+          "data": Array [],
+          "meta": Object {
+            "total": 0,
+          },
+        },
+      },
+      Object {
+        "display_name": "test4.rhel.aprice.local",
+        "id": "f5ac67e1-ad65-4b62-bc27-845cc6d4bc04",
+        "tags": Object {
+          "data": Array [],
+          "meta": Object {
+            "total": 0,
           },
         },
       },

--- a/src/resolvers/hosts/hosts.integration.ts
+++ b/src/resolvers/hosts/hosts.integration.ts
@@ -550,9 +550,12 @@ describe('hosts query', function () {
                 test('spf_operating_system_name', async () => {
                     const { data } = await runQuery(BASIC_QUERY,
                         { filter: { spf_operating_system: {name: { eq: 'RHEL'}}}});
-                    data.hosts.data.should.have.length(2);
+                    data.hosts.data.should.have.length(5);
                     data.hosts.data[0].id.should.equal('6e7b6317-0a2d-4552-a2f2-b7da0aece49d');
                     data.hosts.data[1].id.should.equal('22cd8e39-13bb-4d02-8316-84b850dc5136');
+                    data.hosts.data[2].id.should.equal('f5ac67e1-ad65-4b62-bc27-845cc6d4bc01');
+                    data.hosts.data[3].id.should.equal('f5ac67e1-ad65-4b62-bc27-845cc6d4bc03');
+                    data.hosts.data[4].id.should.equal('f5ac67e1-ad65-4b62-bc27-845cc6d4bc04');
                 });
 
                 test('spf_operating_system_combined', async () => {

--- a/src/resolvers/hosts/index.ts
+++ b/src/resolvers/hosts/index.ts
@@ -139,9 +139,20 @@ function customOperatingSystemSort(order_how: any) {
             type: 'string',
             script: {
                 lang: 'painless',
-                source: `doc['system_profile_facts.operating_system.name'].value + ' '
-                + doc['system_profile_facts.operating_system.major'].value + '.'
-                + doc['system_profile_facts.operating_system.minor'].value`
+                source: `
+                String name = '';
+                long major = 0;
+                long minor = 0;
+                if (doc['system_profile_facts.operating_system.name'].size() != 0) {
+                    name = doc['system_profile_facts.operating_system.name'].value;
+                }
+                if (doc['system_profile_facts.operating_system.major'].size() != 0) {
+                    major = doc['system_profile_facts.operating_system.major'].value;
+                }
+                if (doc['system_profile_facts.operating_system.minor'].size() != 0) {
+                    minor = doc['system_profile_facts.operating_system.minor'].value;
+                }
+                return name + ' ' + major + '.' + minor;`
             },
             order: String(order_how)
         }

--- a/test/hosts.json
+++ b/test/hosts.json
@@ -226,6 +226,96 @@
         ]
     },
     {
+        "id": "f5ac67e1-ad65-4b62-bc27-845cc6d4bc01",
+        "account": "test",
+        "display_name": "test1.rhel7.aprice.local",
+        "created_on": "2019-03-10T08:07:03.354307Z",
+        "modified_on": "2019-03-10T08:07:03.354312Z",
+        "stale_timestamp": "2030-03-10T08:07:03.354307Z",
+        "reporter": "puptoo",
+        "ansible_host": "test01.rhel7.aprice.local",
+        "canonical_facts": {
+            "fqdn": "fqdn.test1.rhel7.aprice.local",
+            "insights_id": "371e0253-b145-4428-9f7a-7d934aad9801",
+            "satellite_id": "ce87bfac-a6cb-43a0-80ce-95d9669db701",
+            "subscription_manager_id":"1d073c47-8467-4372-b585-7b0d40d2ee01"
+        },
+        "system_profile_facts": {
+            "owner_id": "it8i99u1-48ut-1rdf-bc10-84opf904test",
+            "operating_system": {
+                "name": "RHEL"
+            }
+        }
+    },
+    {
+        "id": "f5ac67e1-ad65-4b62-bc27-845cc6d4bc02",
+        "account": "test",
+        "display_name": "test2.rhel7.aprice.local",
+        "created_on": "2019-03-10T08:07:03.354307Z",
+        "modified_on": "2019-03-10T08:07:03.354312Z",
+        "stale_timestamp": "2030-03-10T08:07:03.354307Z",
+        "reporter": "puptoo",
+        "ansible_host": "test02.rhel7.aprice.local",
+        "canonical_facts": {
+            "fqdn": "fqdn.test2.rhel7.aprice.local",
+            "insights_id": "371e0253-b145-4428-9f7a-7d934aad9802",
+            "satellite_id": "ce87bfac-a6cb-43a0-80ce-95d9669db702",
+            "subscription_manager_id":"1d073c47-8467-4372-b585-7b0d40d2ee02"
+        },
+        "system_profile_facts": {
+            "owner_id": "it8i99u1-48ut-1rdf-bc10-84opf904test",
+            "operating_system": {
+                "major": 8
+            }
+        }
+    },
+    {
+        "id": "f5ac67e1-ad65-4b62-bc27-845cc6d4bc03",
+        "account": "test",
+        "display_name": "test3.rhel8.aprice.local",
+        "created_on": "2019-03-10T08:07:03.354307Z",
+        "modified_on": "2019-03-10T08:07:03.354312Z",
+        "stale_timestamp": "2030-03-10T08:07:03.354307Z",
+        "reporter": "puptoo",
+        "ansible_host": "test03.rhel8.aprice.local",
+        "canonical_facts": {
+            "fqdn": "fqdn.test3.rhel8.aprice.local",
+            "insights_id": "371e0253-b145-4428-9f7a-7d934aad9803",
+            "satellite_id": "ce87bfac-a6cb-43a0-80ce-95d9669db703",
+            "subscription_manager_id":"1d073c47-8467-4372-b585-7b0d40d2ee03"
+        },
+        "system_profile_facts": {
+            "owner_id": "it8i99u1-48ut-1rdf-bc10-84opf904test",
+            "operating_system": {
+                "name": "RHEL",
+                "major": 8
+            }
+        }
+    },
+    {
+        "id": "f5ac67e1-ad65-4b62-bc27-845cc6d4bc04",
+        "account": "test",
+        "display_name": "test4.rhel.aprice.local",
+        "created_on": "2019-03-10T08:07:03.354307Z",
+        "modified_on": "2019-03-10T08:07:03.354312Z",
+        "stale_timestamp": "2030-03-10T08:07:03.354307Z",
+        "reporter": "puptoo",
+        "ansible_host": "test04.rhel.aprice.local",
+        "canonical_facts": {
+            "fqdn": "fqdn.test4.rhel.aprice.local",
+            "insights_id": "371e0253-b145-4428-9f7a-7d934aad9804",
+            "satellite_id": "ce87bfac-a6cb-43a0-80ce-95d9669db704",
+            "subscription_manager_id":"1d073c47-8467-4372-b585-7b0d40d2ee04"
+        },
+        "system_profile_facts": {
+            "owner_id": "it8i99u1-48ut-1rdf-bc10-84opf904test",
+            "operating_system": {
+                "name": "RHEL",
+                "minor": 7
+            }
+        }
+    },
+    {
         "id": "a5ac67e1-ad65-4b62-bc27-845cc6d4bcea",
         "account": "12345",
         "display_name": "test03.rhel7.jharting.local",


### PR DESCRIPTION
This PR addresses a bug introduced in #123, which would cause the query to fail if any of the operating_system fields were null. I also added some test hosts with different combinations of missing operating_system fields to verify that the update worked (thus the updated snapshots).