### PR TITLE
OS version ordering fix

### DIFF
--- a/src/resolvers/hosts/__snapshots__/hosts.integration.ts.snap
+++ b/src/resolvers/hosts/__snapshots__/hosts.integration.ts.snap
@@ -545,7 +545,7 @@ Object {
           "number_of_sockets": 1,
           "operating_system": Object {
             "major": 7,
-            "minor": 4,
+            "minor": 11,
             "name": "RHEL",
           },
           "os_kernel_version": "3.10.0",
@@ -614,7 +614,7 @@ Object {
           "number_of_sockets": 1,
           "operating_system": Object {
             "major": 7,
-            "minor": 4,
+            "minor": 11,
             "name": "RHEL",
           },
           "os_kernel_version": "3.10.0",

--- a/src/resolvers/hosts/index.ts
+++ b/src/resolvers/hosts/index.ts
@@ -142,7 +142,7 @@ function customOperatingSystemSort(order_how: any) {
                 source: `
                 String name = '';
                 long major = 0;
-                long minor = 0;
+                String minor = '0';
                 if (doc['system_profile_facts.operating_system.name'].size() != 0) {
                     name = doc['system_profile_facts.operating_system.name'].value;
                 }
@@ -150,7 +150,7 @@ function customOperatingSystemSort(order_how: any) {
                     major = doc['system_profile_facts.operating_system.major'].value;
                 }
                 if (doc['system_profile_facts.operating_system.minor'].size() != 0) {
-                    minor = doc['system_profile_facts.operating_system.minor'].value;
+                    minor = String.format('%010d', new def[] {doc['system_profile_facts.operating_system.minor'].value});
                 }
                 return name + ' ' + major + '.' + minor;`
             },

--- a/src/resolvers/hosts/index.ts
+++ b/src/resolvers/hosts/index.ts
@@ -141,13 +141,13 @@ function customOperatingSystemSort(order_how: any) {
                 lang: 'painless',
                 source: `
                 String name = '';
-                long major = 0;
+                String major = '0';
                 String minor = '0';
                 if (doc['system_profile_facts.operating_system.name'].size() != 0) {
                     name = doc['system_profile_facts.operating_system.name'].value;
                 }
                 if (doc['system_profile_facts.operating_system.major'].size() != 0) {
-                    major = doc['system_profile_facts.operating_system.major'].value;
+                    major = String.format('%010d', new def[] {doc['system_profile_facts.operating_system.major'].value});
                 }
                 if (doc['system_profile_facts.operating_system.minor'].size() != 0) {
                     minor = String.format('%010d', new def[] {doc['system_profile_facts.operating_system.minor'].value});

--- a/test/hosts.json
+++ b/test/hosts.json
@@ -121,7 +121,7 @@
             "rhc_client_id": "33cd8e39-13bb-4d02-8316-84b850dc5136",
             "operating_system": {
                 "major": 7,
-                "minor": 4,
+                "minor": 11,
                 "name": "RHEL"
             },
             "ansible": {


### PR DESCRIPTION
The current sorting script compares the whole OS as a single string, meaning "RHEL 8.2" > "RHEL 8.10". To combat this, this PR updates the sorting script to separately format the major and minor versions, prepending with the character `0` enough times to make each a 10-digit representation.

So with this change, the above example would actually result in the comparison "RHEL 0000000008.0000000002" < "RHEL 0000000008.0000000010", which is what we want.