### PR TITLE
Allow filtering of operating_system field (and other filterInts) using "eq"

### DIFF
--- a/docs/schema.md
+++ b/docs/schema.md
@@ -710,6 +710,15 @@ Timestamp field filter with support for common operations.
 </thead>
 <tbody>
 <tr>
+<td colspan="2" valign="top"><strong>eq</strong></td>
+<td valign="top"><a href="#int">Int</a></td>
+<td>
+
+Equal to
+
+</td>
+</tr>
+<tr>
 <td colspan="2" valign="top"><strong>lt</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
 <td>
@@ -775,7 +784,7 @@ Major release version (0-99)
 <td valign="top"><a href="#filterint">FilterInt</a></td>
 <td>
 
-Minor release version (0-99
+Minor release version (0-99)
 
 </td>
 </tr>

--- a/src/generated/graphql.ts
+++ b/src/generated/graphql.ts
@@ -61,6 +61,8 @@ export type FilterBoolean = {
 
 /** Timestamp field filter with support for common operations. */
 export type FilterInt = {
+  /** Equal to */
+  eq?: Maybe<Scalars['Int']>;
   /** Less than */
   lt?: Maybe<Scalars['Int']>;
   /** Less than or equal to */
@@ -75,7 +77,7 @@ export type FilterInt = {
 export type FilterOperatingSystem = {
   /** Major release version (0-99) */
   major?: Maybe<FilterInt>;
-  /** Minor release version (0-99 */
+  /** Minor release version (0-99) */
   minor?: Maybe<FilterInt>;
   /** Name of distro (max 4 chars e.g. RHEL) */
   name?: Maybe<FilterString>;

--- a/src/resolvers/hosts/hosts.integration.ts
+++ b/src/resolvers/hosts/hosts.integration.ts
@@ -568,6 +568,17 @@ describe('hosts query', function () {
                     data.hosts.data.should.have.length(1);
                     data.hosts.data[0].id.should.equal('22cd8e39-13bb-4d02-8316-84b850dc5136');
                 });
+
+                test('spf_operating_system_eq', async () => {
+                    const { data } = await runQuery(BASIC_QUERY,
+                        { filter: { spf_operating_system: {
+                            name: { eq: 'RHEL'},
+                            major: { eq: 7 },
+                            minor: { eq: 3 }
+                        }}});
+                    data.hosts.data.should.have.length(1);
+                    data.hosts.data[0].id.should.equal('22cd8e39-13bb-4d02-8316-84b850dc5136');
+                });
             });
 
             describe('ansible', function () {

--- a/src/resolvers/inputInt.ts
+++ b/src/resolvers/inputInt.ts
@@ -1,14 +1,21 @@
 import { FilterInt } from '../generated/graphql';
+import { term } from './es';
 
 export function filterInt(field: string, filter: FilterInt): Record<string, any>[] {
-    return [{
-        range: {
-            [field]: {
-                gte: filter.gte,
-                lte: filter.lte,
-                gt: filter.gt,
-                lt: filter.lt
+    if (!filter.eq) {
+        return [{
+            range: {
+                [field]: {
+                    gte: filter.gte,
+                    lte: filter.lte,
+                    gt: filter.gt,
+                    lt: filter.lt
+                }
             }
-        }
-    }];
+        }];
+    } else if (filter.eq !== undefined) {
+        return [term(field, filter.eq)];
+    }
+
+    return [];
 }

--- a/src/schema/schema.graphql
+++ b/src/schema/schema.graphql
@@ -226,6 +226,9 @@ input FilterTag {
 Timestamp field filter with support for common operations.
 """
 input FilterInt {
+    "Equal to"
+    eq: Int
+
     "Less than"
     lt: Int
 
@@ -246,7 +249,7 @@ input FilterOperatingSystem {
     "Major release version (0-99)"
     major: FilterInt,
 
-    "Minor release version (0-99"
+    "Minor release version (0-99)"
     minor: FilterInt,
 
     "Name of distro (max 4 chars e.g. RHEL)"


### PR DESCRIPTION
In addition to filtering fields like operating_system using a range, we also need to be able to filter using exact matches. So, this PR adds an optional "eq" operation to the FilterInt type and modifies the resolver to work with either.

Also, I closed a parenthetical that was left open because it was bugging me.