### PR TITLE
Patch ephemeral mapping updater

### DIFF
--- a/scripts/update_from_schema.ts
+++ b/scripts/update_from_schema.ts
@@ -149,8 +149,9 @@ function updateEphemeralMapping(schema: JSONSchema) {
     })
 
     if(_.has(xjoinConfigMap, "data")) {
-        console.log("modifying!")
-        xjoinConfigMap["data"]["elasticsearch.index.template"] = JSON.stringify(mapping, null, 2);
+        let xjoinConfigMapIndexTemplate = JSON.parse(xjoinConfigMap["data"]["elasticsearch.index.template"]);
+        xjoinConfigMapIndexTemplate["mappings"] = mapping;
+        xjoinConfigMap["data"]["elasticsearch.index.template"] = JSON.stringify(xjoinConfigMapIndexTemplate, null, 2);
     }
 
     console.log(xjoinConfigMap);

--- a/scripts/update_from_schema.ts
+++ b/scripts/update_from_schema.ts
@@ -154,8 +154,6 @@ function updateEphemeralMapping(schema: JSONSchema) {
         xjoinConfigMap["data"]["elasticsearch.index.template"] = JSON.stringify(xjoinConfigMapIndexTemplate, null, 2);
     }
 
-    console.log(xjoinConfigMap);
-
     let i = 0
     _.forEach(objects, (o: any) => {
         if(_.get(o, "metadata") && _.get(o, "metadata.name") == "xjoin") {


### PR DESCRIPTION
Now the template in the ephemeral xjoin-search configmap will include all aspects of the pipeline and only update the mapping portion from the script.