### PR TITLE
Fix ephemeral update

### DIFF
--- a/scripts/update_from_schema.ts
+++ b/scripts/update_from_schema.ts
@@ -403,7 +403,7 @@ function updateEphemeralMapping(schema: JSONSchema) {
 
     if(_.has(xjoinConfigMap, "data")) {
         let xjoinConfigMapIndexTemplate = JSON.parse(xjoinConfigMap["data"]["elasticsearch.index.template"]);
-        xjoinConfigMapIndexTemplate["mappings"] = mapping;
+        xjoinConfigMapIndexTemplate["mappings"]["properties"]["system_profile_facts"] = mapping["properties"]["system_profile_facts"];
         xjoinConfigMap["data"]["elasticsearch.index.template"] = JSON.stringify(xjoinConfigMapIndexTemplate, null, 2);
     }
 


### PR DESCRIPTION
Updated the ephemeral mapping updater to only modify system_profile_facts. The removal of the lowercase modifier was a byproduct of this. Now when the script is run, existing configuration outside of `system_profile_facts` remains the same. 