### PR TITLE
Add per-reporter staleness to schema

### DIFF
--- a/docs/schema.md
+++ b/docs/schema.md
@@ -356,6 +356,20 @@ Facts of a host. The subset of keys can be requested using `filter`.
 <td valign="top">[<a href="#string">String</a>!]</td>
 <td></td>
 </tr>
+<tr>
+<td colspan="2" valign="top"><strong>per_reporter_staleness</strong></td>
+<td valign="top"><a href="#jsonobject">JSONObject</a></td>
+<td>
+
+Per-reporter staleness data for a host. The subset of keys can be requested using `filter`.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">filter</td>
+<td valign="top">[<a href="#string">String</a>!]</td>
+<td></td>
+</tr>
 </tbody>
 </table>
 

--- a/src/generated/graphql.ts
+++ b/src/generated/graphql.ts
@@ -294,6 +294,8 @@ export type Host = {
   tags?: Maybe<Tags>;
   /** Facts of a host. The subset of keys can be requested using `filter`. */
   facts?: Maybe<Scalars['JSONObject']>;
+  /** Per-reporter staleness data for a host. The subset of keys can be requested using `filter`. */
+  per_reporter_staleness?: Maybe<Scalars['JSONObject']>;
 };
 
 
@@ -311,6 +313,12 @@ export type HostSystem_Profile_FactsArgs = {
 
 /** Inventory host */
 export type HostFactsArgs = {
+  filter?: Maybe<Array<Scalars['String']>>;
+};
+
+
+/** Inventory host */
+export type HostPer_Reporter_StalenessArgs = {
   filter?: Maybe<Array<Scalars['String']>>;
 };
 
@@ -805,6 +813,7 @@ export type HostResolvers<ContextType = any, ParentType extends ResolversParentT
   system_profile_facts?: Resolver<Maybe<ResolversTypes['JSONObject']>, ParentType, ContextType, RequireFields<HostSystem_Profile_FactsArgs, never>>;
   tags?: Resolver<Maybe<ResolversTypes['Tags']>, ParentType, ContextType>;
   facts?: Resolver<Maybe<ResolversTypes['JSONObject']>, ParentType, ContextType, RequireFields<HostFactsArgs, never>>;
+  per_reporter_staleness?: Resolver<Maybe<ResolversTypes['JSONObject']>, ParentType, ContextType, RequireFields<HostPer_Reporter_StalenessArgs, never>>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 

--- a/src/resolvers/hosts/__snapshots__/hosts.integration.ts.snap
+++ b/src/resolvers/hosts/__snapshots__/hosts.integration.ts.snap
@@ -36,6 +36,25 @@ Object {
 }
 `;
 
+exports[`hosts query fetch host with per-reporter staleness 1`] = `
+Object {
+  "hosts": Object {
+    "data": Array [
+      Object {
+        "id": "f5ac67e1-ad65-4b62-bc27-845cc6d4bcee",
+        "per_reporter_staleness": Object {
+          "puptoo": Object {
+            "check_in_succeeded": true,
+            "last_check_in": "2019-01-10T08:07:03.354312Z",
+            "stale_timestamp": "2030-01-10T08:07:03.354307Z",
+          },
+        },
+      },
+    ],
+  },
+}
+`;
+
 exports[`hosts query fetch hosts 1`] = `
 Object {
   "hosts": Object {

--- a/src/resolvers/hosts/hosts.integration.ts
+++ b/src/resolvers/hosts/hosts.integration.ts
@@ -128,6 +128,26 @@ describe('hosts query', function () {
         expect(data).toMatchSnapshot();
     });
 
+    test('fetch host with per-reporter staleness', async () => {
+        const { data, status } = await runQuery(`
+            {
+                hosts (
+                    filter: {
+                        id: {
+                            eq: "f5ac67e1-ad65-4b62-bc27-845cc6d4bcee"
+                        }
+                    }
+                ) {
+                    data {
+                        id, per_reporter_staleness
+                    }
+                }
+            }`,
+        {});
+        expect(status).toEqual(200);
+        expect(data).toMatchSnapshot();
+    });
+
     describe ('ordering', function () {
 
         test('display_name ASC', async () => {

--- a/src/resolvers/index.ts
+++ b/src/resolvers/index.ts
@@ -16,7 +16,8 @@ const resolvers = {
     Host: {
         system_profile_facts: jsonObjectFilter('system_profile_facts'),
         canonical_facts: jsonObjectFilter('canonical_facts'),
-        facts: jsonObjectFilter('facts')
+        facts: jsonObjectFilter('facts'),
+        per_reporter_staleness: jsonObjectFilter('per_reporter_staleness')
     },
 
     HostSystemProfile: {

--- a/src/schema/schema.graphql
+++ b/src/schema/schema.graphql
@@ -608,6 +608,9 @@ type Host {
 
     "Facts of a host. The subset of keys can be requested using `filter`."
     facts (filter: [String!]): JSONObject
+
+    "Per-reporter staleness data for a host. The subset of keys can be requested using `filter`."
+    per_reporter_staleness (filter: [String!]): JSONObject,
 }
 
 type Hosts {

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -20,6 +20,18 @@ const HOST_TEMPLATE =     {
         insights_id: 'd4d30804-93a5-463c-86d4-e639443fb5c5'
     },
     system_profile_facts: {},
+    per_reporter_staleness: {
+        puptoo: {
+            last_check_in: '2019-03-10T08:07:03.354312Z',
+            stale_timestamp: '2030-03-10T08:07:03.354307Z',
+            check_in_succeeded: true
+        },
+        yupana: {
+            last_check_in: '2019-03-10T08:07:03.354312Z',
+            stale_timestamp: '2030-03-10T08:07:03.354307Z',
+            check_in_succeeded: true
+        }
+    },
     tags_structured: [{
         namespace: 'insights-client',
         key: 'os',

--- a/test/hosts.json
+++ b/test/hosts.json
@@ -157,6 +157,13 @@
                 "bios.version": "1.11.0-2.el7",
                 "bios.release_date": "2014-04-01"
             }
+        },
+        "per_reporter_staleness": {
+            "puptoo": {
+                "last_check_in": "2019-01-10T08:07:03.354312Z",
+                "stale_timestamp": "2030-01-10T08:07:03.354307Z",
+                "check_in_succeeded": true
+            }
         }
     },
     {
@@ -295,7 +302,14 @@
             "Sat/env/prod",
             "aws/region/us-east-1",
             "insights-client/database/"
-        ]
+        ],
+        "per_reporter_staleness": {
+            "puptoo": {
+                "last_check_in": "2019-01-10T08:07:03.354312Z",
+                "stale_timestamp": "2030-01-10T08:07:03.354307Z",
+                "check_in_succeeded": true
+            }
+        }
     },
     {
         "id": "f5ac67e1-ad65-4b62-bc27-845cc6d4bcee",
@@ -440,7 +454,14 @@
             "aws/region/us-east-3",
             "insights-client/database/",
             "insights-client/os/fedora"
-        ]
+        ],
+        "per_reporter_staleness": {
+            "puptoo": {
+                "last_check_in": "2019-01-10T08:07:03.354312Z",
+                "stale_timestamp": "2030-01-10T08:07:03.354307Z",
+                "check_in_succeeded": true
+            }
+        }
     },
     {
         "id": "f5ac67e1-ad65-4b62-bc27-845cc6d4bc01",
@@ -461,6 +482,13 @@
             "owner_id": "it8i99u1-48ut-1rdf-bc10-84opf904test",
             "operating_system": {
                 "name": "RHEL"
+            }
+        },
+        "per_reporter_staleness": {
+            "puptoo": {
+                "last_check_in": "2019-01-10T08:07:03.354312Z",
+                "stale_timestamp": "2030-01-10T08:07:03.354307Z",
+                "check_in_succeeded": true
             }
         }
     },
@@ -507,6 +535,13 @@
                 "name": "CENT",
                 "major": 8
             }
+        },
+        "per_reporter_staleness": {
+            "puptoo": {
+                "last_check_in": "2019-01-10T08:07:03.354312Z",
+                "stale_timestamp": "2030-01-10T08:07:03.354307Z",
+                "check_in_succeeded": true
+            }
         }
     },
     {
@@ -529,6 +564,13 @@
             "operating_system": {
                 "name": "CENT",
                 "minor": 7
+            }
+        },
+        "per_reporter_staleness": {
+            "puptoo": {
+                "last_check_in": "2019-01-10T08:07:03.354312Z",
+                "stale_timestamp": "2030-01-10T08:07:03.354307Z",
+                "check_in_succeeded": true
             }
         }
     },
@@ -565,6 +607,13 @@
             "insights_client_version": "3.0.6-2.el7_6",
             "system_memory_bytes": 511451136,
             "satellite_managed": false
+        },
+        "per_reporter_staleness": {
+            "puptoo": {
+                "last_check_in": "2019-01-10T08:07:03.354312Z",
+                "stale_timestamp": "2030-01-10T08:07:03.354307Z",
+                "check_in_succeeded": true
+            }
         }
     },
     {
@@ -601,6 +650,13 @@
             "insights_client_version": "3.0.6-2.el7_6",
             "system_memory_bytes": 511451136,
             "satellite_managed": false
+        },
+        "per_reporter_staleness": {
+            "puptoo": {
+                "last_check_in": "2019-01-10T08:07:03.354312Z",
+                "stale_timestamp": "2030-01-10T08:07:03.354307Z",
+                "check_in_succeeded": true
+            }
         }
     },
     {
@@ -635,6 +691,13 @@
             "insights_client_version": "3.0.6-2.el7_6",
             "system_memory_bytes": 511451136,
             "satellite_managed": false
+        },
+        "per_reporter_staleness": {
+            "puptoo": {
+                "last_check_in": "2019-01-10T08:07:03.354312Z",
+                "stale_timestamp": "2030-01-10T08:07:03.354307Z",
+                "check_in_succeeded": true
+            }
         }
     },
     {
@@ -669,6 +732,13 @@
             "insights_client_version": "3.0.6-2.el7_6",
             "system_memory_bytes": 511451136,
             "satellite_managed": false
+        },
+        "per_reporter_staleness": {
+            "puptoo": {
+                "last_check_in": "2019-01-10T08:07:03.354312Z",
+                "stale_timestamp": "2030-01-10T08:07:03.354307Z",
+                "check_in_succeeded": true
+            }
         }
     },
     {
@@ -703,6 +773,13 @@
             "insights_client_version": "3.0.6-2.el7_6",
             "system_memory_bytes": 511451136,
             "satellite_managed": false
+        },
+        "per_reporter_staleness": {
+            "puptoo": {
+                "last_check_in": "2019-01-10T08:07:03.354312Z",
+                "stale_timestamp": "2030-01-10T08:07:03.354307Z",
+                "check_in_succeeded": true
+            }
         }
     },
     {
@@ -737,6 +814,13 @@
             "insights_client_version": "3.0.6-2.el7_6",
             "system_memory_bytes": 511451136,
             "satellite_managed": false
+        },
+        "per_reporter_staleness": {
+            "puptoo": {
+                "last_check_in": "2019-01-10T08:07:03.354312Z",
+                "stale_timestamp": "2030-01-10T08:07:03.354307Z",
+                "check_in_succeeded": true
+            }
         }
     },
     {
@@ -792,7 +876,14 @@
             "Sat/env/prod",
             "aws/region/us-east-1",
             "insights-client/database/"
-        ]
+        ],
+        "per_reporter_staleness": {
+            "puptoo": {
+                "last_check_in": "2019-01-10T08:07:03.354312Z",
+                "stale_timestamp": "2030-01-10T08:07:03.354307Z",
+                "check_in_succeeded": true
+            }
+        }
     },
     {
         "id": "6e7b6339-9y2d-4552-a2f2-b7da0aece49d",
@@ -847,7 +938,14 @@
             "Sat/env/prod",
             "aws/region/us-east-1",
             "insights-client/database/"
-        ]
+        ],
+        "per_reporter_staleness": {
+            "puptoo": {
+                "last_check_in": "2019-01-10T08:07:03.354312Z",
+                "stale_timestamp": "2030-01-10T08:07:03.354307Z",
+                "check_in_succeeded": true
+            }
+        }
     },
     {
         "id": "d1119a66-ffb7-4529-a8ca-15439aed29ad",
@@ -864,6 +962,13 @@
         },
         "system_profile_facts": {
             "arch": "x86_64"
+        },
+        "per_reporter_staleness": {
+            "puptoo": {
+                "last_check_in": "2019-01-10T08:07:03.354312Z",
+                "stale_timestamp": "2030-01-10T08:07:03.354307Z",
+                "check_in_succeeded": true
+            }
         }
     },
     {
@@ -946,7 +1051,14 @@
             "insights-client/foo/6",
             "insights-client/foo/7",
             "insights-client/foo/8"
-        ]
+        ],
+        "per_reporter_staleness": {
+            "puptoo": {
+                "last_check_in": "2019-01-10T08:07:03.354312Z",
+                "stale_timestamp": "2030-01-10T08:07:03.354307Z",
+                "check_in_succeeded": true
+            }
+        }
     },
     {
         "id": "f2fea2de-5dd5-4f32-a6c1-142c7affc321",
@@ -1013,7 +1125,14 @@
             "insights-client/bar/6",
             "insights-client/bar/7",
             "insights-client/bar/8"
-        ]
+        ],
+        "per_reporter_staleness": {
+            "puptoo": {
+                "last_check_in": "2019-01-10T08:07:03.354312Z",
+                "stale_timestamp": "2030-01-10T08:07:03.354307Z",
+                "check_in_succeeded": true
+            }
+        }
     },
     {
         "id": "399886f1-fcb5-43d8-be70-f4bbdb02d4b0",
@@ -1038,7 +1157,14 @@
         ],
         "tags_string": [
             "null/foo"
-        ]
+        ],
+        "per_reporter_staleness": {
+            "puptoo": {
+                "last_check_in": "2019-01-10T08:07:03.354312Z",
+                "stale_timestamp": "2030-01-10T08:07:03.354307Z",
+                "check_in_succeeded": true
+            }
+        }
     },
     {
         "id": "bd37baad-ce97-4488-ba0c-fb93edd36f7f",
@@ -1060,7 +1186,14 @@
                 "key": "os",
                 "value": "fedora"
             }
-        ]
+        ],
+        "per_reporter_staleness": {
+            "puptoo": {
+                "last_check_in": "2019-01-10T08:07:03.354312Z",
+                "stale_timestamp": "2030-01-10T08:07:03.354307Z",
+                "check_in_succeeded": true
+            }
+        }
     },
     {
         "id": "b72cf877-3433-4755-b172-65700a56545a",
@@ -1097,6 +1230,13 @@
                 "key": "key",
                 "value": "value"
             }
-        ]
+        ],
+        "per_reporter_staleness": {
+            "puptoo": {
+                "last_check_in": "2019-01-10T08:07:03.354312Z",
+                "stale_timestamp": "2030-01-10T08:07:03.354307Z",
+                "check_in_succeeded": true
+            }
+        }
     }
 ]


### PR DESCRIPTION
Addresses [ESSNTL-2445](https://issues.redhat.com/browse/ESSNTL-2445). Adds per-reporter staleness to the Host schema.
Will need [this xjoin-operator PR](https://github.com/RedHatInsights/xjoin-operator/pull/7) to be merged in order to actually return data.