### PR TITLE
Add per_reporter_staleness filter

### DIFF
--- a/docs/schema.md
+++ b/docs/schema.md
@@ -12,6 +12,7 @@
     * [HostSystemProfile](#hostsystemprofile)
     * [HostTags](#hosttags)
     * [Hosts](#hosts)
+    * [PerReporterStaleness](#perreporterstaleness)
     * [StringValueInfo](#stringvalueinfo)
     * [StringValues](#stringvalues)
     * [StructuredTag](#structuredtag)
@@ -20,6 +21,7 @@
   * [Inputs](#inputs)
     * [FilterAnsible](#filteransible)
     * [FilterBoolean](#filterboolean)
+    * [FilterPerReporterStaleness](#filterperreporterstaleness)
     * [FilterDiskDevices](#filterdiskdevices)
     * [FilterDnfModules](#filterdnfmodules)
     * [FilterInstalledProducts](#filterinstalledproducts)
@@ -358,10 +360,10 @@ Facts of a host. The subset of keys can be requested using `filter`.
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>per_reporter_staleness</strong></td>
-<td valign="top"><a href="#jsonobject">JSONObject</a></td>
+<td valign="top">[<a href="#perreporterstaleness">PerReporterStaleness</a>]</td>
 <td>
 
-Per-reporter staleness data for a host. The subset of keys can be requested using `filter`.
+Per-reporter staleness data for a host.
 
 </td>
 </tr>
@@ -498,6 +500,41 @@ Lists unique values of the `sap_sids` field
 <tr>
 <td colspan="2" valign="top"><strong>meta</strong></td>
 <td valign="top"><a href="#collectionmeta">CollectionMeta</a>!</td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### PerReporterStaleness
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>reporter</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>last_check_in</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>stale_timestamp</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>check_in_succeeded</strong></td>
+<td valign="top"><a href="#boolean">Boolean</a></td>
 <td></td>
 </tr>
 </tbody>
@@ -1156,6 +1193,42 @@ Filter by 'booted' field of rpm_ostree_deployments
 Filter by 'pinned' field of rpm_ostree_deployments
 
 </td>
+</tr>
+</tbody>
+</table>
+
+### FilterPerReporterStaleness
+
+Per reporter timestamp field filter.
+
+<table>
+<thead>
+<tr>
+<th colspan="2" align="left">Field</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>reporter</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>stale_timestamp</strong></td>
+<td valign="top"><a href="#filtertimestamp">FilterTimestamp</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>last_check_in</strong></td>
+<td valign="top"><a href="#filtertimestamp">FilterTimestamp</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>check_in_succeeded</strong></td>
+<td valign="top"><a href="#filterboolean">FilterBoolean</a></td>
+<td></td>
 </tr>
 </tbody>
 </table>
@@ -2038,6 +2111,15 @@ Filter by the stale_timestamp value
 <td>
 
 Filter by host tag. The tag namespace/key/value must match exactly what the host is tagged with
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>per_reporter_staleness</strong></td>
+<td valign="top"><a href="#filterperreporterstaleness">FilterPerReporterStaleness</a></td>
+<td>
+
+Filter by 'stale_timestamp' field of per_reporter_staleness
 
 </td>
 </tr>

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -21,7 +21,6 @@
   * [Inputs](#inputs)
     * [FilterAnsible](#filteransible)
     * [FilterBoolean](#filterboolean)
-    * [FilterPerReporterStaleness](#filterperreporterstaleness)
     * [FilterDiskDevices](#filterdiskdevices)
     * [FilterDnfModules](#filterdnfmodules)
     * [FilterInstalledProducts](#filterinstalledproducts)
@@ -29,6 +28,7 @@
     * [FilterMssql](#filtermssql)
     * [FilterNetworkInterfaces](#filternetworkinterfaces)
     * [FilterOperatingSystem](#filteroperatingsystem)
+    * [FilterPerReporterStaleness](#filterperreporterstaleness)
     * [FilterRhsm](#filterrhsm)
     * [FilterRpmOstreeDeployments](#filterrpmostreedeployments)
     * [FilterString](#filterstring)
@@ -363,14 +363,9 @@ Facts of a host. The subset of keys can be requested using `filter`.
 <td valign="top">[<a href="#perreporterstaleness">PerReporterStaleness</a>]</td>
 <td>
 
-Per-reporter staleness data for a host.
+Per-reporter staleness of the host
 
 </td>
-</tr>
-<tr>
-<td colspan="2" align="right" valign="top">filter</td>
-<td valign="top">[<a href="#string">String</a>!]</td>
-<td></td>
 </tr>
 </tbody>
 </table>
@@ -1093,6 +1088,42 @@ Filter by 'name' field of operating_system
 </tbody>
 </table>
 
+### FilterPerReporterStaleness
+
+Per reporter timestamp field filter.
+
+<table>
+<thead>
+<tr>
+<th colspan="2" align="left">Field</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>reporter</strong></td>
+<td valign="top"><a href="#filterstring">FilterString</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>stale_timestamp</strong></td>
+<td valign="top"><a href="#filtertimestamp">FilterTimestamp</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>last_check_in</strong></td>
+<td valign="top"><a href="#filtertimestamp">FilterTimestamp</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>check_in_succeeded</strong></td>
+<td valign="top"><a href="#filterboolean">FilterBoolean</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
 ### FilterRhsm
 
 Filter by 'rhsm' field of system profile
@@ -1193,42 +1224,6 @@ Filter by 'booted' field of rpm_ostree_deployments
 Filter by 'pinned' field of rpm_ostree_deployments
 
 </td>
-</tr>
-</tbody>
-</table>
-
-### FilterPerReporterStaleness
-
-Per reporter timestamp field filter.
-
-<table>
-<thead>
-<tr>
-<th colspan="2" align="left">Field</th>
-<th align="left">Type</th>
-<th align="left">Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td colspan="2" valign="top"><strong>reporter</strong></td>
-<td valign="top"><a href="#string">String</a>!</td>
-<td></td>
-</tr>
-<tr>
-<td colspan="2" valign="top"><strong>stale_timestamp</strong></td>
-<td valign="top"><a href="#filtertimestamp">FilterTimestamp</a></td>
-<td></td>
-</tr>
-<tr>
-<td colspan="2" valign="top"><strong>last_check_in</strong></td>
-<td valign="top"><a href="#filtertimestamp">FilterTimestamp</a></td>
-<td></td>
-</tr>
-<tr>
-<td colspan="2" valign="top"><strong>check_in_succeeded</strong></td>
-<td valign="top"><a href="#filterboolean">FilterBoolean</a></td>
-<td></td>
 </tr>
 </tbody>
 </table>

--- a/src/generated/graphql.ts
+++ b/src/generated/graphql.ts
@@ -139,6 +139,14 @@ export type FilterOperatingSystem = {
   name?: Maybe<FilterString>;
 };
 
+/** Per reporter timestamp field filter. */
+export type FilterPerReporterStaleness = {
+  check_in_succeeded?: Maybe<FilterBoolean>;
+  last_check_in?: Maybe<FilterTimestamp>;
+  reporter?: Maybe<FilterString>;
+  stale_timestamp?: Maybe<FilterTimestamp>;
+};
+
 /** Filter by 'rhsm' field of system profile */
 export type FilterRhsm = {
   /** Filter by 'version' field of rhsm */
@@ -161,14 +169,6 @@ export type FilterRpmOstreeDeployments = {
   pinned?: Maybe<FilterBoolean>;
   /** Filter by 'version' field of rpm_ostree_deployments */
   version?: Maybe<FilterString>;
-};
-
-/** Per reporter timestamp field filter. */
-export type FilterPerReporterStaleness = {
-  reporter?: Maybe<FilterString>;
-  stale_timestamp?: Maybe<FilterTimestamp>;
-  last_check_in?: Maybe<FilterTimestamp>;
-  check_in_succeeded?: Maybe<FilterBoolean>;
 };
 
 /** Basic filter for string fields that allows filtering based on exact match. */
@@ -297,13 +297,13 @@ export type Host = {
   facts?: Maybe<Scalars['JSONObject']>;
   id: Scalars['ID'];
   modified_on?: Maybe<Scalars['String']>;
+  /** Per-reporter staleness of the host */
+  per_reporter_staleness?: Maybe<Array<Maybe<PerReporterStaleness>>>;
   reporter?: Maybe<Scalars['String']>;
   stale_timestamp?: Maybe<Scalars['String']>;
   /** System profile of a host. The subset of keys can be requested using `filter`. */
   system_profile_facts?: Maybe<Scalars['JSONObject']>;
   tags?: Maybe<Tags>;
-  /** per reporter staleness of the host */
-  per_reporter_staleness?: Maybe<Array<Maybe<PerReporterStaleness>>>;
 };
 
 
@@ -315,12 +315,6 @@ export type HostCanonical_FactsArgs = {
 
 /** Inventory host */
 export type HostFactsArgs = {
-  filter?: Maybe<Array<Scalars['String']>>;
-};
-
-
-/** Inventory host */
-export type HostPer_Reporter_StalenessArgs = {
   filter?: Maybe<Array<Scalars['String']>>;
 };
 
@@ -346,6 +340,8 @@ export type HostFilter = {
   id?: Maybe<FilterStringWithWildcard>;
   /** Filter by insights id */
   insights_id?: Maybe<FilterStringWithWildcard>;
+  /** Filter by 'stale_timestamp' field of per_reporter_staleness */
+  per_reporter_staleness?: Maybe<FilterPerReporterStaleness>;
   /** Filter by provider_id */
   provider_id?: Maybe<FilterString>;
   /** Filter by provider_type */
@@ -456,8 +452,6 @@ export type HostFilter = {
   stale_timestamp?: Maybe<FilterTimestamp>;
   /** Filter by host tag. The tag namespace/key/value must match exactly what the host is tagged with */
   tag?: Maybe<FilterTag>;
-  /** Filter by 'stale_timestamp' field of per_reporter_staleness */
-  per_reporter_staleness?: Maybe<FilterPerReporterStaleness>;
 };
 
 /** Lists unique system profile values. */
@@ -509,10 +503,10 @@ export enum Order_Dir {
 
 export type PerReporterStaleness = {
   __typename?: 'PerReporterStaleness';
-  reporter?: Maybe<Scalars['String']>;
-  last_check_in?: Maybe<Scalars['String']>;
-  stale_timestamp?: Maybe<Scalars['String']>;
   check_in_succeeded?: Maybe<Scalars['Boolean']>;
+  last_check_in?: Maybe<Scalars['String']>;
+  reporter?: Maybe<Scalars['String']>;
+  stale_timestamp?: Maybe<Scalars['String']>;
 };
 
 export type Query = {
@@ -769,6 +763,7 @@ export type ResolversParentTypes = {
   FilterMssql: FilterMssql;
   FilterNetworkInterfaces: FilterNetworkInterfaces;
   FilterOperatingSystem: FilterOperatingSystem;
+  FilterPerReporterStaleness: FilterPerReporterStaleness;
   FilterRhsm: FilterRhsm;
   FilterRpmOstreeDeployments: FilterRpmOstreeDeployments;
   FilterString: FilterString;
@@ -777,7 +772,6 @@ export type ResolversParentTypes = {
   FilterStringWithWildcardWithLowercase: FilterStringWithWildcardWithLowercase;
   FilterSystemPurpose: FilterSystemPurpose;
   FilterTag: FilterTag;
-  FilterPerReporterStaleness: FilterPerReporterStaleness;
   FilterTimestamp: FilterTimestamp;
   Host: Host;
   HostFilter: HostFilter;
@@ -865,6 +859,14 @@ export interface JsonObjectScalarConfig extends GraphQLScalarTypeConfig<Resolver
   name: 'JSONObject';
 }
 
+export type PerReporterStalenessResolvers<ContextType = any, ParentType extends ResolversParentTypes['PerReporterStaleness'] = ResolversParentTypes['PerReporterStaleness']> = {
+  check_in_succeeded?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
+  last_check_in?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  reporter?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  stale_timestamp?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
 export type QueryResolvers<ContextType = any, ParentType extends ResolversParentTypes['Query'] = ResolversParentTypes['Query']> = {
   hostSystemProfile?: Resolver<Maybe<ResolversTypes['HostSystemProfile']>, ParentType, ContextType, RequireFields<QueryHostSystemProfileArgs, never>>;
   hostTags?: Resolver<Maybe<ResolversTypes['HostTags']>, ParentType, ContextType, RequireFields<QueryHostTagsArgs, 'limit' | 'offset' | 'order_by' | 'order_how'>>;
@@ -913,6 +915,7 @@ export type Resolvers<ContextType = any> = {
   Hosts?: HostsResolvers<ContextType>;
   JSON?: GraphQLScalarType;
   JSONObject?: GraphQLScalarType;
+  PerReporterStaleness?: PerReporterStalenessResolvers<ContextType>;
   Query?: QueryResolvers<ContextType>;
   StringValueInfo?: StringValueInfoResolvers<ContextType>;
   StringValues?: StringValuesResolvers<ContextType>;

--- a/src/generated/graphql.ts
+++ b/src/generated/graphql.ts
@@ -163,6 +163,14 @@ export type FilterRpmOstreeDeployments = {
   version?: Maybe<FilterString>;
 };
 
+/** Per reporter timestamp field filter. */
+export type FilterPerReporterStaleness = {
+  reporter?: Maybe<FilterString>;
+  stale_timestamp?: Maybe<FilterTimestamp>;
+  last_check_in?: Maybe<FilterTimestamp>;
+  check_in_succeeded?: Maybe<FilterBoolean>;
+};
+
 /** Basic filter for string fields that allows filtering based on exact match. */
 export type FilterString = {
   /**
@@ -289,13 +297,13 @@ export type Host = {
   facts?: Maybe<Scalars['JSONObject']>;
   id: Scalars['ID'];
   modified_on?: Maybe<Scalars['String']>;
-  /** Per-reporter staleness data for a host. The subset of keys can be requested using `filter`. */
-  per_reporter_staleness?: Maybe<Scalars['JSONObject']>;
   reporter?: Maybe<Scalars['String']>;
   stale_timestamp?: Maybe<Scalars['String']>;
   /** System profile of a host. The subset of keys can be requested using `filter`. */
   system_profile_facts?: Maybe<Scalars['JSONObject']>;
   tags?: Maybe<Tags>;
+  /** per reporter staleness of the host */
+  per_reporter_staleness?: Maybe<Array<Maybe<PerReporterStaleness>>>;
 };
 
 
@@ -448,6 +456,8 @@ export type HostFilter = {
   stale_timestamp?: Maybe<FilterTimestamp>;
   /** Filter by host tag. The tag namespace/key/value must match exactly what the host is tagged with */
   tag?: Maybe<FilterTag>;
+  /** Filter by 'stale_timestamp' field of per_reporter_staleness */
+  per_reporter_staleness?: Maybe<FilterPerReporterStaleness>;
 };
 
 /** Lists unique system profile values. */
@@ -496,6 +506,14 @@ export enum Order_Dir {
   Asc = 'ASC',
   Desc = 'DESC'
 }
+
+export type PerReporterStaleness = {
+  __typename?: 'PerReporterStaleness';
+  reporter?: Maybe<Scalars['String']>;
+  last_check_in?: Maybe<Scalars['String']>;
+  stale_timestamp?: Maybe<Scalars['String']>;
+  check_in_succeeded?: Maybe<Scalars['Boolean']>;
+};
 
 export type Query = {
   __typename?: 'Query';
@@ -700,6 +718,7 @@ export type ResolversTypes = {
   FilterMssql: FilterMssql;
   FilterNetworkInterfaces: FilterNetworkInterfaces;
   FilterOperatingSystem: FilterOperatingSystem;
+  FilterPerReporterStaleness: FilterPerReporterStaleness;
   FilterRhsm: FilterRhsm;
   FilterRpmOstreeDeployments: FilterRpmOstreeDeployments;
   FilterString: FilterString;
@@ -721,6 +740,7 @@ export type ResolversTypes = {
   JSON: ResolverTypeWrapper<Scalars['JSON']>;
   JSONObject: ResolverTypeWrapper<Scalars['JSONObject']>;
   ORDER_DIR: Order_Dir;
+  PerReporterStaleness: ResolverTypeWrapper<PerReporterStaleness>;
   Query: ResolverTypeWrapper<{}>;
   SapSidFilter: SapSidFilter;
   String: ResolverTypeWrapper<Scalars['String']>;
@@ -757,6 +777,7 @@ export type ResolversParentTypes = {
   FilterStringWithWildcardWithLowercase: FilterStringWithWildcardWithLowercase;
   FilterSystemPurpose: FilterSystemPurpose;
   FilterTag: FilterTag;
+  FilterPerReporterStaleness: FilterPerReporterStaleness;
   FilterTimestamp: FilterTimestamp;
   Host: Host;
   HostFilter: HostFilter;
@@ -767,6 +788,7 @@ export type ResolversParentTypes = {
   Int: Scalars['Int'];
   JSON: Scalars['JSON'];
   JSONObject: Scalars['JSONObject'];
+  PerReporterStaleness: PerReporterStaleness;
   Query: {};
   SapSidFilter: SapSidFilter;
   String: Scalars['String'];
@@ -809,7 +831,7 @@ export type HostResolvers<ContextType = any, ParentType extends ResolversParentT
   facts?: Resolver<Maybe<ResolversTypes['JSONObject']>, ParentType, ContextType, RequireFields<HostFactsArgs, never>>;
   id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
   modified_on?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  per_reporter_staleness?: Resolver<Maybe<ResolversTypes['JSONObject']>, ParentType, ContextType, RequireFields<HostPer_Reporter_StalenessArgs, never>>;
+  per_reporter_staleness?: Resolver<Maybe<Array<Maybe<ResolversTypes['PerReporterStaleness']>>>, ParentType, ContextType>;
   reporter?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   stale_timestamp?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   system_profile_facts?: Resolver<Maybe<ResolversTypes['JSONObject']>, ParentType, ContextType, RequireFields<HostSystem_Profile_FactsArgs, never>>;

--- a/src/resolvers/hosts/__snapshots__/hosts.integration.ts.snap
+++ b/src/resolvers/hosts/__snapshots__/hosts.integration.ts.snap
@@ -42,13 +42,20 @@ Object {
     "data": Array [
       Object {
         "id": "f5ac67e1-ad65-4b62-bc27-845cc6d4bcee",
-        "per_reporter_staleness": Object {
-          "puptoo": Object {
+        "per_reporter_staleness": Array [
+          Object {
             "check_in_succeeded": true,
-            "last_check_in": "2019-01-10T08:07:03.354312Z",
-            "stale_timestamp": "2030-01-10T08:07:03.354307Z",
+            "last_check_in": "2019-03-09T08:07:03.354307Z",
+            "reporter": "puptoo",
+            "stale_timestamp": "2019-03-10T08:07:03.354307Z",
           },
-        },
+          Object {
+            "check_in_succeeded": false,
+            "last_check_in": "2019-01-10T08:07:03.354307Z",
+            "reporter": "yupana",
+            "stale_timestamp": "2019-01-11T08:07:03.354307Z",
+          },
+        ],
       },
     ],
   },

--- a/src/resolvers/hosts/hosts.integration.ts
+++ b/src/resolvers/hosts/hosts.integration.ts
@@ -169,7 +169,13 @@ describe('hosts query', function () {
                     }
                 ) {
                     data {
-                        id, per_reporter_staleness
+                        id,
+                        per_reporter_staleness {
+                            reporter
+                            last_check_in
+                            stale_timestamp
+                            check_in_succeeded
+                        }
                     }
                 }
             }`,
@@ -1139,7 +1145,7 @@ describe('hosts query', function () {
         describe('per_reporter_staleness', function () {
             test('reporter', async () => {
                 const { data } = await runQuery(PRS_QUERY,
-                    { filter: { per_reporter_staleness: { reporter: 'yupana' }}});
+                    { filter: { per_reporter_staleness: { reporter: { eq: 'yupana' }}}});
                 data.hosts.data.should.have.length(2);
                 data.hosts.data[0].id.should.equal('6e7b6317-0a2d-4552-a2f2-b7da0aece49d');
                 data.hosts.data[1].id.should.equal('f5ac67e1-ad65-4b62-bc27-845cc6d4bcee');
@@ -1147,7 +1153,7 @@ describe('hosts query', function () {
 
             test('reporter and check in succeeded', async () => {
                 const { data } = await runQuery(PRS_QUERY,
-                    { filter: { per_reporter_staleness: { reporter: 'yupana', check_in_succeeded: {is: true}}}});
+                    { filter: { per_reporter_staleness: { reporter: {eq: 'yupana'}, check_in_succeeded: {is: true}}}});
                 data.hosts.data.should.have.length(1);
                 data.hosts.data[0].id.should.equal('6e7b6317-0a2d-4552-a2f2-b7da0aece49d');
             });
@@ -1181,7 +1187,7 @@ describe('hosts query', function () {
                         check_in_succeeded: {is: true}
                     }}});
                 data.hosts.data.should.have.length(1);
-                data.hosts.data[0].id.should.equal('22cd8e39-13bb-4d02-8316-84b850dc5136');
+                data.hosts.data[0].id.should.equal('f5ac67e1-ad65-4b62-bc27-845cc6d4bcee');
             });
 
         });

--- a/src/resolvers/hosts/hosts.integration.ts
+++ b/src/resolvers/hosts/hosts.integration.ts
@@ -112,9 +112,9 @@ const PRS_QUERY = `
                 account,
                 display_name,
                 per_reporter_staleness {
-                    reporter
-                    last_check_in
-                    stale_timestamp
+                    reporter,
+                    last_check_in,
+                    stale_timestamp,
                     check_in_succeeded
                 }
             }

--- a/src/resolvers/hosts/hosts.integration.ts
+++ b/src/resolvers/hosts/hosts.integration.ts
@@ -92,6 +92,36 @@ const TEST_ACCOUNT_HOST_IDS: string[] = [
     'f5ac67e1-ad65-4b62-bc27-845cc6d4bc01'
 ];
 
+const PRS_QUERY = `
+    query hosts (
+        $filter: HostFilter,
+        $order_by: HOSTS_ORDER_BY,
+        $order_how: ORDER_DIR,
+        $limit: Int,
+        $offset: Int) {
+        hosts (
+            filter: $filter,
+            order_by: $order_by,
+            order_how: $order_how,
+            limit: $limit,
+            offset: $offset
+        )
+        {
+            data {
+                id,
+                account,
+                display_name,
+                per_reporter_staleness {
+                    reporter
+                    last_check_in
+                    stale_timestamp
+                    check_in_succeeded
+                }
+            }
+        }
+    }
+`;
+
 describe('hosts query', function () {
     test('fetch hosts', async () => {
         const { data, status } = await runQuery(BASIC_QUERY, {});
@@ -1104,6 +1134,56 @@ describe('hosts query', function () {
 
                 expect(data).toMatchSnapshot();
             });
+        });
+
+        describe('per_reporter_staleness', function () {
+            test('reporter', async () => {
+                const { data } = await runQuery(PRS_QUERY,
+                    { filter: { per_reporter_staleness: { reporter: 'yupana' }}});
+                data.hosts.data.should.have.length(2);
+                data.hosts.data[0].id.should.equal('6e7b6317-0a2d-4552-a2f2-b7da0aece49d');
+                data.hosts.data[1].id.should.equal('f5ac67e1-ad65-4b62-bc27-845cc6d4bcee');
+            });
+
+            test('reporter and check in succeeded', async () => {
+                const { data } = await runQuery(PRS_QUERY,
+                    { filter: { per_reporter_staleness: { reporter: 'yupana', check_in_succeeded: {is: true}}}});
+                data.hosts.data.should.have.length(1);
+                data.hosts.data[0].id.should.equal('6e7b6317-0a2d-4552-a2f2-b7da0aece49d');
+            });
+
+            test('reporter and stale_timestamp', async () => {
+                const { data } = await runQuery(PRS_QUERY,
+                    { filter: { per_reporter_staleness: {
+                        reporter: {eq: 'yupana'},
+                        stale_timestamp: {lte: '2020-01-11T08:07:03.354307Z'}
+                    }}});
+                data.hosts.data.should.have.length(1);
+                data.hosts.data[0].id.should.equal('f5ac67e1-ad65-4b62-bc27-845cc6d4bcee');
+            });
+
+            test('reporter and last_check_in', async () => {
+                const { data } = await runQuery(PRS_QUERY,
+                    { filter: { per_reporter_staleness: {
+                        reporter: {eq: 'yupana'},
+                        last_check_in: {lte: '2020-01-10T08:07:03.354307Z'}
+                    }}});
+                data.hosts.data.should.have.length(1);
+                data.hosts.data[0].id.should.equal('f5ac67e1-ad65-4b62-bc27-845cc6d4bcee');
+            });
+
+            test('all', async () => {
+                const { data } = await runQuery(PRS_QUERY,
+                    { filter: { per_reporter_staleness: {
+                        reporter: {eq: 'puptoo'},
+                        last_check_in: {lte: '2020-01-09T08:07:03.354307Z'},
+                        stale_timestamp: {lte: '2020-01-10T08:07:03.354307Z'},
+                        check_in_succeeded: {is: true}
+                    }}});
+                data.hosts.data.should.have.length(1);
+                data.hosts.data[0].id.should.equal('22cd8e39-13bb-4d02-8316-84b850dc5136');
+            });
+
         });
     });
 

--- a/src/resolvers/hosts/index.ts
+++ b/src/resolvers/hosts/index.ts
@@ -16,6 +16,7 @@ import { filterTag } from '../inputTag';
 import { formatTags } from './format';
 import { filterString } from '../inputString';
 import { getSchema, getFieldType, getResolver } from '../../util/systemProfile';
+import { filterPerReporterStaleness } from '../inputPerReporterStaleness';
 
 export type HostFilterResolver = FilterResolver<HostFilter>;
 
@@ -62,7 +63,11 @@ function getPredefinedResolvers() {
         optional((filter: HostFilter) => filter.tag, filterTag),
         optional((filter: HostFilter) => filter.OR, common.or(resolveFilters)),
         optional((filter: HostFilter) => filter.AND, common.and(resolveFilters)),
-        optional((filter: HostFilter) => filter.NOT, common.not(resolveFilter))
+        optional((filter: HostFilter) => filter.NOT, common.not(resolveFilter)),
+        optional(
+            (filter: HostFilter) => filter.per_reporter_staleness,
+            _.partial(filterPerReporterStaleness)
+        )
     ];
 }
 

--- a/src/resolvers/index.ts
+++ b/src/resolvers/index.ts
@@ -16,8 +16,7 @@ const resolvers = {
     Host: {
         system_profile_facts: jsonObjectFilter('system_profile_facts'),
         canonical_facts: jsonObjectFilter('canonical_facts'),
-        facts: jsonObjectFilter('facts'),
-        per_reporter_staleness: jsonObjectFilter('per_reporter_staleness')
+        facts: jsonObjectFilter('facts')
     },
 
     HostSystemProfile: {

--- a/src/resolvers/inputPerReporterStaleness.ts
+++ b/src/resolvers/inputPerReporterStaleness.ts
@@ -37,13 +37,12 @@ export function filterPerReporterStaleness(filter: FilterPerReporterStaleness) {
             path: 'per_reporter_staleness',
             query: {
                 bool: {
-                    must: [
-                        stringTerm(filter.reporter),
-                        booleanTerm(filter.check_in_succeeded),
-                        timestampTerm('per_reporter_staleness.last_check_in', filter.last_check_in),
-                        timestampTerm('per_reporter_staleness.stale_timestamp', filter.stale_timestamp)
-                    ]
-
+                    must:
+                        stringTerm(filter.reporter).concat(
+                            booleanTerm(filter.check_in_succeeded),
+                            timestampTerm('per_reporter_staleness.last_check_in', filter.last_check_in),
+                            timestampTerm('per_reporter_staleness.stale_timestamp', filter.stale_timestamp)
+                        )
                 }
             }
         }

--- a/src/resolvers/inputPerReporterStaleness.ts
+++ b/src/resolvers/inputPerReporterStaleness.ts
@@ -1,0 +1,51 @@
+import { FilterPerReporterStaleness, FilterTimestamp } from '../generated/graphql';
+import { filterBoolean } from './inputBoolean';
+import { FilterBoolean } from '../generated/graphql';
+import { filterString } from './inputString';
+import { FilterString} from '../generated/graphql';
+import { filterTimestamp } from './inputTimestamp';
+
+type Resolved = Record<string, any>[];
+
+function booleanTerm (filter: FilterBoolean | null | undefined): Resolved {
+    if (filter !== null && filter !== undefined) {
+        return filterBoolean('per_reporter_staleness.check_in_succeeded', filter);
+    }
+
+    return [];
+}
+
+function timestampTerm (field: string, filter: FilterTimestamp | null | undefined): Resolved {
+    if (filter !== null && filter !== undefined) {
+        return filterTimestamp(field, filter);
+    }
+
+    return [];
+}
+
+function stringTerm (filter: FilterString | null | undefined): Resolved {
+    if (filter !== null && filter !== undefined) {
+        return filterString('per_reporter_staleness.reporter', filter);
+    }
+
+    return [];
+}
+
+export function filterPerReporterStaleness(filter: FilterPerReporterStaleness) {
+    return [{
+        nested: {
+            path: 'per_reporter_staleness',
+            query: {
+                bool: {
+                    must: [
+                        stringTerm(filter.reporter),
+                        booleanTerm(filter.check_in_succeeded),
+                        timestampTerm('per_reporter_staleness.last_check_in', filter.last_check_in),
+                        timestampTerm('per_reporter_staleness.stale_timestamp', filter.stale_timestamp)
+                    ]
+
+                }
+            }
+        }
+    }];
+}

--- a/src/schema/schema.graphql
+++ b/src/schema/schema.graphql
@@ -228,6 +228,9 @@ input HostFilter {
 
     "Filter by host tag. The tag namespace/key/value must match exactly what the host is tagged with"
     tag: FilterTag
+
+    "Filter by 'stale_timestamp' field of per_reporter_staleness"
+    per_reporter_staleness: FilterPerReporterStaleness
 }
 
 """
@@ -581,7 +584,15 @@ input FilterNetworkInterfaces {
 
 }
 
-
+"""
+Per reporter timestamp field filter.
+"""
+input FilterPerReporterStaleness {
+    reporter: FilterString
+    stale_timestamp: FilterTimestamp
+    last_check_in: FilterTimestamp
+    check_in_succeeded: FilterBoolean
+}
 
 #
 # Output types
@@ -616,6 +627,13 @@ type Host {
 type Hosts {
     data: [Host]!
     meta: CollectionMeta!
+}
+
+type PerReporterStaleness {
+    reporter: String,
+    last_check_in: String,
+    stale_timestamp: String,
+    check_in_succeeded: Boolean
 }
 
 "Structured representation of a tag"

--- a/src/schema/schema.graphql
+++ b/src/schema/schema.graphql
@@ -620,8 +620,8 @@ type Host {
     "Facts of a host. The subset of keys can be requested using `filter`."
     facts (filter: [String!]): JSONObject
 
-    "Per-reporter staleness data for a host. The subset of keys can be requested using `filter`."
-    per_reporter_staleness (filter: [String!]): JSONObject,
+    "Per-reporter staleness of the host"
+    per_reporter_staleness: [PerReporterStaleness]
 }
 
 type Hosts {

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -20,18 +20,17 @@ const HOST_TEMPLATE =     {
         insights_id: 'd4d30804-93a5-463c-86d4-e639443fb5c5'
     },
     system_profile_facts: {},
-    per_reporter_staleness: {
-        puptoo: {
-            last_check_in: '2019-03-10T08:07:03.354312Z',
-            stale_timestamp: '2030-03-10T08:07:03.354307Z',
-            check_in_succeeded: true
-        },
-        yupana: {
-            last_check_in: '2019-03-10T08:07:03.354312Z',
-            stale_timestamp: '2030-03-10T08:07:03.354307Z',
-            check_in_succeeded: true
-        }
-    },
+    per_reporter_staleness: [{
+        reporter: 'puptoo',
+        last_check_in: '2019-03-10T08:07:03.354312Z',
+        stale_timestamp: '2030-03-10T08:07:03.354307Z',
+        check_in_succeeded: true
+    }, {
+        reporter: 'yupana',
+        last_check_in: '2019-03-10T08:07:03.354312Z',
+        stale_timestamp: '2030-03-10T08:07:03.354307Z',
+        check_in_succeeded: true
+    }],
     tags_structured: [{
         namespace: 'insights-client',
         key: 'os',

--- a/test/hosts.json
+++ b/test/hosts.json
@@ -158,13 +158,14 @@
                 "bios.release_date": "2014-04-01"
             }
         },
-        "per_reporter_staleness": {
-            "puptoo": {
+        "per_reporter_staleness": [
+            {
+                "reporter": "puptoo",
                 "last_check_in": "2019-01-10T08:07:03.354312Z",
                 "stale_timestamp": "2030-01-10T08:07:03.354307Z",
                 "check_in_succeeded": true
             }
-        }
+        ]
     },
     {
         "id": "6e7b6317-0a2d-4552-a2f2-b7da0aece49d",
@@ -303,13 +304,14 @@
             "aws/region/us-east-1",
             "insights-client/database/"
         ],
-        "per_reporter_staleness": {
-            "puptoo": {
-                "last_check_in": "2019-01-10T08:07:03.354312Z",
-                "stale_timestamp": "2030-01-10T08:07:03.354307Z",
+        "per_reporter_staleness": [
+            {
+                "reporter": "yupana",
+                "last_check_in":"2029-02-09T08:07:03.354307Z",
+                "stale_timestamp": "2029-02-10T08:07:03.354307Z",
                 "check_in_succeeded": true
             }
-        }
+        ]
     },
     {
         "id": "f5ac67e1-ad65-4b62-bc27-845cc6d4bcee",
@@ -455,13 +457,20 @@
             "insights-client/database/",
             "insights-client/os/fedora"
         ],
-        "per_reporter_staleness": {
-            "puptoo": {
-                "last_check_in": "2019-01-10T08:07:03.354312Z",
-                "stale_timestamp": "2030-01-10T08:07:03.354307Z",
+        "per_reporter_staleness": [
+            {
+                "reporter": "puptoo",
+                "last_check_in": "2019-03-09T08:07:03.354307Z",
+                "stale_timestamp": "2019-03-10T08:07:03.354307Z",
                 "check_in_succeeded": true
+            },
+            {
+                "reporter": "yupana",
+                "last_check_in": "2019-01-10T08:07:03.354307Z",
+                "stale_timestamp": "2019-01-11T08:07:03.354307Z",
+                "check_in_succeeded": false
             }
-        }
+        ]
     },
     {
         "id": "f5ac67e1-ad65-4b62-bc27-845cc6d4bc01",
@@ -484,13 +493,14 @@
                 "name": "RHEL"
             }
         },
-        "per_reporter_staleness": {
-            "puptoo": {
+        "per_reporter_staleness": [
+            {
+                "reporter": "puptoo",
                 "last_check_in": "2019-01-10T08:07:03.354312Z",
                 "stale_timestamp": "2030-01-10T08:07:03.354307Z",
                 "check_in_succeeded": true
             }
-        }
+        ]
     },
     {
         "id": "f5ac67e1-ad65-4b62-bc27-845cc6d4bc02",
@@ -536,13 +546,14 @@
                 "major": 8
             }
         },
-        "per_reporter_staleness": {
-            "puptoo": {
+        "per_reporter_staleness": [
+            {
+                "reporter": "puptoo",
                 "last_check_in": "2019-01-10T08:07:03.354312Z",
                 "stale_timestamp": "2030-01-10T08:07:03.354307Z",
                 "check_in_succeeded": true
             }
-        }
+        ]
     },
     {
         "id": "f5ac67e1-ad65-4b62-bc27-845cc6d4bc04",
@@ -566,13 +577,14 @@
                 "minor": 7
             }
         },
-        "per_reporter_staleness": {
-            "puptoo": {
+        "per_reporter_staleness": [
+            {
+                "reporter": "puptoo",
                 "last_check_in": "2019-01-10T08:07:03.354312Z",
                 "stale_timestamp": "2030-01-10T08:07:03.354307Z",
                 "check_in_succeeded": true
             }
-        }
+        ]
     },
     {
         "id": "a5ac67e1-ad65-4b62-bc27-845cc6d4bcea",
@@ -608,13 +620,14 @@
             "system_memory_bytes": 511451136,
             "satellite_managed": false
         },
-        "per_reporter_staleness": {
-            "puptoo": {
+        "per_reporter_staleness": [
+            {
+                "reporter": "puptoo",
                 "last_check_in": "2019-01-10T08:07:03.354312Z",
                 "stale_timestamp": "2030-01-10T08:07:03.354307Z",
                 "check_in_succeeded": true
             }
-        }
+        ]
     },
     {
         "id": "a5ac67e1-ad65-4b62-bc27-845cc6d4bceb",
@@ -651,13 +664,14 @@
             "system_memory_bytes": 511451136,
             "satellite_managed": false
         },
-        "per_reporter_staleness": {
-            "puptoo": {
+        "per_reporter_staleness": [
+            {
+                "reporter": "puptoo",
                 "last_check_in": "2019-01-10T08:07:03.354312Z",
                 "stale_timestamp": "2030-01-10T08:07:03.354307Z",
                 "check_in_succeeded": true
             }
-        }
+        ]
     },
     {
         "id": "a5ac67e1-ad65-4b62-bc27-845cc6d4bcec",
@@ -692,13 +706,14 @@
             "system_memory_bytes": 511451136,
             "satellite_managed": false
         },
-        "per_reporter_staleness": {
-            "puptoo": {
+        "per_reporter_staleness": [
+            {
+                "reporter": "puptoo",
                 "last_check_in": "2019-01-10T08:07:03.354312Z",
                 "stale_timestamp": "2030-01-10T08:07:03.354307Z",
                 "check_in_succeeded": true
             }
-        }
+        ]
     },
     {
         "id": "a5ac67e1-ad65-4b62-bc27-845cc6d4bced",
@@ -733,13 +748,14 @@
             "system_memory_bytes": 511451136,
             "satellite_managed": false
         },
-        "per_reporter_staleness": {
-            "puptoo": {
+        "per_reporter_staleness": [
+            {
+                "reporter": "puptoo",
                 "last_check_in": "2019-01-10T08:07:03.354312Z",
                 "stale_timestamp": "2030-01-10T08:07:03.354307Z",
                 "check_in_succeeded": true
             }
-        }
+        ]
     },
     {
         "id": "a5ac67e1-ad65-4b62-bc27-845cc6d4bc69",
@@ -774,13 +790,14 @@
             "system_memory_bytes": 511451136,
             "satellite_managed": false
         },
-        "per_reporter_staleness": {
-            "puptoo": {
+        "per_reporter_staleness": [
+            {
+                "reporter": "puptoo",
                 "last_check_in": "2019-01-10T08:07:03.354312Z",
                 "stale_timestamp": "2030-01-10T08:07:03.354307Z",
                 "check_in_succeeded": true
             }
-        }
+        ]
     },
     {
         "id": "a5ac67e1-ad65-5c79-bc27-845cc6d4bc69",
@@ -815,13 +832,14 @@
             "system_memory_bytes": 511451136,
             "satellite_managed": false
         },
-        "per_reporter_staleness": {
-            "puptoo": {
+        "per_reporter_staleness": [
+            {
+                "reporter": "puptoo",
                 "last_check_in": "2019-01-10T08:07:03.354312Z",
                 "stale_timestamp": "2030-01-10T08:07:03.354307Z",
                 "check_in_succeeded": true
             }
-        }
+        ]
     },
     {
         "id": "6e7b6339-0a2d-4552-a2f2-b7da0aece49d",
@@ -877,13 +895,14 @@
             "aws/region/us-east-1",
             "insights-client/database/"
         ],
-        "per_reporter_staleness": {
-            "puptoo": {
+        "per_reporter_staleness": [
+            {
+                "reporter": "puptoo",
                 "last_check_in": "2019-01-10T08:07:03.354312Z",
                 "stale_timestamp": "2030-01-10T08:07:03.354307Z",
                 "check_in_succeeded": true
             }
-        }
+        ]
     },
     {
         "id": "6e7b6339-9y2d-4552-a2f2-b7da0aece49d",
@@ -939,13 +958,14 @@
             "aws/region/us-east-1",
             "insights-client/database/"
         ],
-        "per_reporter_staleness": {
-            "puptoo": {
+        "per_reporter_staleness": [
+            {
+                "reporter": "puptoo",
                 "last_check_in": "2019-01-10T08:07:03.354312Z",
                 "stale_timestamp": "2030-01-10T08:07:03.354307Z",
                 "check_in_succeeded": true
             }
-        }
+        ]
     },
     {
         "id": "d1119a66-ffb7-4529-a8ca-15439aed29ad",
@@ -963,13 +983,14 @@
         "system_profile_facts": {
             "arch": "x86_64"
         },
-        "per_reporter_staleness": {
-            "puptoo": {
+        "per_reporter_staleness": [
+            {
+                "reporter": "puptoo",
                 "last_check_in": "2019-01-10T08:07:03.354312Z",
                 "stale_timestamp": "2030-01-10T08:07:03.354307Z",
                 "check_in_succeeded": true
             }
-        }
+        ]
     },
     {
         "id": "5212d66b-62bf-49ee-8f96-dbb5d866fa2a",
@@ -1052,13 +1073,14 @@
             "insights-client/foo/7",
             "insights-client/foo/8"
         ],
-        "per_reporter_staleness": {
-            "puptoo": {
+        "per_reporter_staleness": [
+            {
+                "reporter": "puptoo",
                 "last_check_in": "2019-01-10T08:07:03.354312Z",
                 "stale_timestamp": "2030-01-10T08:07:03.354307Z",
                 "check_in_succeeded": true
             }
-        }
+        ]
     },
     {
         "id": "f2fea2de-5dd5-4f32-a6c1-142c7affc321",
@@ -1126,13 +1148,14 @@
             "insights-client/bar/7",
             "insights-client/bar/8"
         ],
-        "per_reporter_staleness": {
-            "puptoo": {
+        "per_reporter_staleness": [
+            {
+                "reporter": "puptoo",
                 "last_check_in": "2019-01-10T08:07:03.354312Z",
                 "stale_timestamp": "2030-01-10T08:07:03.354307Z",
                 "check_in_succeeded": true
             }
-        }
+        ]
     },
     {
         "id": "399886f1-fcb5-43d8-be70-f4bbdb02d4b0",
@@ -1158,13 +1181,14 @@
         "tags_string": [
             "null/foo"
         ],
-        "per_reporter_staleness": {
-            "puptoo": {
+        "per_reporter_staleness": [
+            {
+                "reporter": "puptoo",
                 "last_check_in": "2019-01-10T08:07:03.354312Z",
                 "stale_timestamp": "2030-01-10T08:07:03.354307Z",
                 "check_in_succeeded": true
             }
-        }
+        ]
     },
     {
         "id": "bd37baad-ce97-4488-ba0c-fb93edd36f7f",
@@ -1187,13 +1211,14 @@
                 "value": "fedora"
             }
         ],
-        "per_reporter_staleness": {
-            "puptoo": {
+        "per_reporter_staleness": [
+            {
+                "reporter": "puptoo",
                 "last_check_in": "2019-01-10T08:07:03.354312Z",
                 "stale_timestamp": "2030-01-10T08:07:03.354307Z",
                 "check_in_succeeded": true
             }
-        }
+        ]
     },
     {
         "id": "b72cf877-3433-4755-b172-65700a56545a",
@@ -1231,12 +1256,13 @@
                 "value": "value"
             }
         ],
-        "per_reporter_staleness": {
-            "puptoo": {
+        "per_reporter_staleness": [
+            {
+                "reporter": "puptoo",
                 "last_check_in": "2019-01-10T08:07:03.354312Z",
                 "stale_timestamp": "2030-01-10T08:07:03.354307Z",
                 "check_in_succeeded": true
             }
-        }
+        ]
     }
 ]

--- a/test/mapping.json
+++ b/test/mapping.json
@@ -360,6 +360,23 @@
           "normalizer": "case_insensitive"
         }
       }
+    },
+    "per_reporter_staleness": {
+      "type": "nested",
+      "properties": {
+        "reporter": {
+          "type": "keyword"
+        },
+        "last_check_in": {
+          "type": "date_nanos"
+        },
+        "stale_timestamp": {
+          "type": "date_nanos"
+        },
+        "check_in_succeeded": {
+          "type": "boolean"
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
This is a continuation of PR #85. Adds support for a new flter on per_report_staleness data.

```
filter: {
    per_reporter_staleness: {
        reporter: "yupana"
        stale_timestamp: {gte: "2020-02-10T08:07:03.354307Z"}
        last_check_in: {gte: "2020-02-09T08:07:03.354307Z"}
        check_in_succeeded: {is: true}
    }
}
```

It also changes the mapping to index this data in elastic search correctly, and adds a way to query the new data:

```
data {
    id
    account
    display_name
    per_reporter_staleness {
        reporter
        stale_timestamp
        last_check_in
        check_in_succeeded
    }
}
```

There are also tests to make sure that the filters work correctly.