### PR TITLE
Support for flattened per-reporter staleness and its filters

### DIFF
--- a/docs/schema.md
+++ b/docs/schema.md
@@ -27,6 +27,7 @@
     * [FilterMssql](#filtermssql)
     * [FilterNetworkInterfaces](#filternetworkinterfaces)
     * [FilterOperatingSystem](#filteroperatingsystem)
+    * [FilterPerReporterStaleness](#filterperreporterstaleness)
     * [FilterRhsm](#filterrhsm)
     * [FilterRpmOstreeDeployments](#filterrpmostreedeployments)
     * [FilterString](#filterstring)
@@ -361,7 +362,21 @@ Facts of a host. The subset of keys can be requested using `filter`.
 <td valign="top"><a href="#jsonobject">JSONObject</a></td>
 <td>
 
-Per-reporter staleness data for a host. The subset of keys can be requested using `filter`.
+The host's per-reporter staleness data in object format.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">filter</td>
+<td valign="top">[<a href="#string">String</a>!]</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>per_reporter_staleness_flat</strong></td>
+<td valign="top">[<a href="#jsonobject">JSONObject</a>]</td>
+<td>
+
+The host's per-reporter staleness, flattened into an array.
 
 </td>
 </tr>
@@ -1052,6 +1067,42 @@ Filter by 'minor' field of operating_system
 Filter by 'name' field of operating_system
 
 </td>
+</tr>
+</tbody>
+</table>
+
+### FilterPerReporterStaleness
+
+Per-reporter staleness filter.
+
+<table>
+<thead>
+<tr>
+<th colspan="2" align="left">Field</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>reporter</strong></td>
+<td valign="top"><a href="#filterstring">FilterString</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>stale_timestamp</strong></td>
+<td valign="top"><a href="#filtertimestamp">FilterTimestamp</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>last_check_in</strong></td>
+<td valign="top"><a href="#filtertimestamp">FilterTimestamp</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>check_in_succeeded</strong></td>
+<td valign="top"><a href="#filterboolean">FilterBoolean</a></td>
+<td></td>
 </tr>
 </tbody>
 </table>
@@ -2038,6 +2089,15 @@ Filter by the stale_timestamp value
 <td>
 
 Filter by host tag. The tag namespace/key/value must match exactly what the host is tagged with
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>per_reporter_staleness</strong></td>
+<td valign="top"><a href="#filterperreporterstaleness">FilterPerReporterStaleness</a></td>
+<td>
+
+Filter by per_reporter_staleness sub-fields
 
 </td>
 </tr>

--- a/src/generated/graphql.ts
+++ b/src/generated/graphql.ts
@@ -139,6 +139,14 @@ export type FilterOperatingSystem = {
   name?: Maybe<FilterString>;
 };
 
+/** Per-reporter staleness filter. */
+export type FilterPerReporterStaleness = {
+  check_in_succeeded?: Maybe<FilterBoolean>;
+  last_check_in?: Maybe<FilterTimestamp>;
+  reporter?: Maybe<FilterString>;
+  stale_timestamp?: Maybe<FilterTimestamp>;
+};
+
 /** Filter by 'rhsm' field of system profile */
 export type FilterRhsm = {
   /** Filter by 'version' field of rhsm */
@@ -289,8 +297,10 @@ export type Host = {
   facts?: Maybe<Scalars['JSONObject']>;
   id: Scalars['ID'];
   modified_on?: Maybe<Scalars['String']>;
-  /** Per-reporter staleness data for a host. The subset of keys can be requested using `filter`. */
+  /** The host's per-reporter staleness data in object format. */
   per_reporter_staleness?: Maybe<Scalars['JSONObject']>;
+  /** The host's per-reporter staleness, flattened into an array. */
+  per_reporter_staleness_flat?: Maybe<Array<Maybe<Scalars['JSONObject']>>>;
   reporter?: Maybe<Scalars['String']>;
   stale_timestamp?: Maybe<Scalars['String']>;
   /** System profile of a host. The subset of keys can be requested using `filter`. */
@@ -318,6 +328,12 @@ export type HostPer_Reporter_StalenessArgs = {
 
 
 /** Inventory host */
+export type HostPer_Reporter_Staleness_FlatArgs = {
+  filter?: Maybe<Array<Scalars['String']>>;
+};
+
+
+/** Inventory host */
 export type HostSystem_Profile_FactsArgs = {
   filter?: Maybe<Array<Scalars['String']>>;
 };
@@ -338,6 +354,8 @@ export type HostFilter = {
   id?: Maybe<FilterStringWithWildcard>;
   /** Filter by insights id */
   insights_id?: Maybe<FilterStringWithWildcard>;
+  /** Filter by per_reporter_staleness sub-fields */
+  per_reporter_staleness?: Maybe<FilterPerReporterStaleness>;
   /** Filter by provider_id */
   provider_id?: Maybe<FilterString>;
   /** Filter by provider_type */
@@ -700,6 +718,7 @@ export type ResolversTypes = {
   FilterMssql: FilterMssql;
   FilterNetworkInterfaces: FilterNetworkInterfaces;
   FilterOperatingSystem: FilterOperatingSystem;
+  FilterPerReporterStaleness: FilterPerReporterStaleness;
   FilterRhsm: FilterRhsm;
   FilterRpmOstreeDeployments: FilterRpmOstreeDeployments;
   FilterString: FilterString;
@@ -749,6 +768,7 @@ export type ResolversParentTypes = {
   FilterMssql: FilterMssql;
   FilterNetworkInterfaces: FilterNetworkInterfaces;
   FilterOperatingSystem: FilterOperatingSystem;
+  FilterPerReporterStaleness: FilterPerReporterStaleness;
   FilterRhsm: FilterRhsm;
   FilterRpmOstreeDeployments: FilterRpmOstreeDeployments;
   FilterString: FilterString;
@@ -810,6 +830,7 @@ export type HostResolvers<ContextType = any, ParentType extends ResolversParentT
   id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
   modified_on?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   per_reporter_staleness?: Resolver<Maybe<ResolversTypes['JSONObject']>, ParentType, ContextType, RequireFields<HostPer_Reporter_StalenessArgs, never>>;
+  per_reporter_staleness_flat?: Resolver<Maybe<Array<Maybe<ResolversTypes['JSONObject']>>>, ParentType, ContextType, RequireFields<HostPer_Reporter_Staleness_FlatArgs, never>>;
   reporter?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   stale_timestamp?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   system_profile_facts?: Resolver<Maybe<ResolversTypes['JSONObject']>, ParentType, ContextType, RequireFields<HostSystem_Profile_FactsArgs, never>>;

--- a/src/resolvers/hosts/__snapshots__/hosts.integration.ts.snap
+++ b/src/resolvers/hosts/__snapshots__/hosts.integration.ts.snap
@@ -45,8 +45,13 @@ Object {
         "per_reporter_staleness": Object {
           "puptoo": Object {
             "check_in_succeeded": true,
-            "last_check_in": "2019-01-10T08:07:03.354312Z",
-            "stale_timestamp": "2030-01-10T08:07:03.354307Z",
+            "last_check_in": "2019-03-09T08:07:03.354307Z",
+            "stale_timestamp": "2019-03-10T08:07:03.354307Z",
+          },
+          "yupana": Object {
+            "check_in_succeeded": false,
+            "last_check_in": "2019-01-10T08:07:03.354307Z",
+            "stale_timestamp": "2019-01-11T08:07:03.354307Z",
           },
         },
       },

--- a/src/resolvers/hosts/index.ts
+++ b/src/resolvers/hosts/index.ts
@@ -16,6 +16,7 @@ import { filterTag } from '../inputTag';
 import { formatTags } from './format';
 import { filterString } from '../inputString';
 import { getSchema, getFieldType, getResolver } from '../../util/systemProfile';
+import { filterPerReporterStaleness } from '../inputPerReporterStaleness';
 
 export type HostFilterResolver = FilterResolver<HostFilter>;
 
@@ -62,7 +63,11 @@ function getPredefinedResolvers() {
         optional((filter: HostFilter) => filter.tag, filterTag),
         optional((filter: HostFilter) => filter.OR, common.or(resolveFilters)),
         optional((filter: HostFilter) => filter.AND, common.and(resolveFilters)),
-        optional((filter: HostFilter) => filter.NOT, common.not(resolveFilter))
+        optional((filter: HostFilter) => filter.NOT, common.not(resolveFilter)),
+        optional(
+            (filter: HostFilter) => filter.per_reporter_staleness,
+            _.partial(filterPerReporterStaleness)
+        )
     ];
 }
 

--- a/src/resolvers/index.ts
+++ b/src/resolvers/index.ts
@@ -16,8 +16,7 @@ const resolvers = {
     Host: {
         system_profile_facts: jsonObjectFilter('system_profile_facts'),
         canonical_facts: jsonObjectFilter('canonical_facts'),
-        facts: jsonObjectFilter('facts'),
-        per_reporter_staleness: jsonObjectFilter('per_reporter_staleness')
+        facts: jsonObjectFilter('facts')
     },
 
     HostSystemProfile: {

--- a/src/resolvers/inputPerReporterStaleness.ts
+++ b/src/resolvers/inputPerReporterStaleness.ts
@@ -1,0 +1,50 @@
+import { FilterPerReporterStaleness, FilterTimestamp } from '../generated/graphql';
+import { filterBoolean } from './inputBoolean';
+import { FilterBoolean } from '../generated/graphql';
+import { filterString } from './inputString';
+import { FilterString} from '../generated/graphql';
+import { filterTimestamp } from './inputTimestamp';
+
+type Resolved = Record<string, any>[];
+
+function booleanTerm (filter: FilterBoolean | null | undefined): Resolved {
+    if (filter !== null && filter !== undefined) {
+        return filterBoolean('per_reporter_staleness_flat.check_in_succeeded', filter);
+    }
+
+    return [];
+}
+
+function timestampTerm (field: string, filter: FilterTimestamp | null | undefined): Resolved {
+    if (filter !== null && filter !== undefined) {
+        return filterTimestamp(field, filter);
+    }
+
+    return [];
+}
+
+function stringTerm (filter: FilterString | null | undefined): Resolved {
+    if (filter !== null && filter !== undefined) {
+        return filterString('per_reporter_staleness_flat.reporter', filter);
+    }
+
+    return [];
+}
+
+export function filterPerReporterStaleness(filter: FilterPerReporterStaleness) {
+    return [{
+        nested: {
+            path: 'per_reporter_staleness_flat',
+            query: {
+                bool: {
+                    must:
+                        stringTerm(filter.reporter).concat(
+                            booleanTerm(filter.check_in_succeeded),
+                            timestampTerm('per_reporter_staleness_flat.last_check_in', filter.last_check_in),
+                            timestampTerm('per_reporter_staleness_flat.stale_timestamp', filter.stale_timestamp)
+                        )
+                }
+            }
+        }
+    }];
+}

--- a/src/schema/schema.graphql
+++ b/src/schema/schema.graphql
@@ -228,6 +228,9 @@ input HostFilter {
 
     "Filter by host tag. The tag namespace/key/value must match exactly what the host is tagged with"
     tag: FilterTag
+
+    "Filter by per_reporter_staleness sub-fields"
+    per_reporter_staleness: FilterPerReporterStaleness
 }
 
 """
@@ -581,7 +584,15 @@ input FilterNetworkInterfaces {
 
 }
 
-
+"""
+Per-reporter staleness filter.
+"""
+input FilterPerReporterStaleness {
+    reporter: FilterString
+    stale_timestamp: FilterTimestamp
+    last_check_in: FilterTimestamp
+    check_in_succeeded: FilterBoolean
+}
 
 #
 # Output types
@@ -609,8 +620,11 @@ type Host {
     "Facts of a host. The subset of keys can be requested using `filter`."
     facts (filter: [String!]): JSONObject
 
-    "Per-reporter staleness data for a host. The subset of keys can be requested using `filter`."
-    per_reporter_staleness (filter: [String!]): JSONObject,
+    "The host's per-reporter staleness data in object format."
+    per_reporter_staleness (filter: [String!]): JSONObject
+
+    "The host's per-reporter staleness, flattened into an array."
+    per_reporter_staleness_flat (filter: [String!]): [JSONObject]
 }
 
 type Hosts {

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -32,6 +32,17 @@ const HOST_TEMPLATE =     {
             check_in_succeeded: true
         }
     },
+    per_reporter_staleness_flat: [{
+        reporter: 'puptoo',
+        last_check_in: '2019-03-10T08:07:03.354312Z',
+        stale_timestamp: '2030-03-10T08:07:03.354307Z',
+        check_in_succeeded: true
+    }, {
+        reporter: 'yupana',
+        last_check_in: '2019-03-10T08:07:03.354312Z',
+        stale_timestamp: '2030-03-10T08:07:03.354307Z',
+        check_in_succeeded: true
+    }],
     tags_structured: [{
         namespace: 'insights-client',
         key: 'os',

--- a/test/hosts.json
+++ b/test/hosts.json
@@ -316,12 +316,23 @@
                 "last_check_in": "2019-01-10T08:07:03.354312Z",
                 "stale_timestamp": "2030-01-10T08:07:03.354307Z",
                 "check_in_succeeded": true
+            },
+            "yupana": {
+                "last_check_in": "2022-01-10T08:07:03.354312Z",
+                "stale_timestamp": "2030-01-10T08:07:03.354307Z",
+                "check_in_succeeded": true
             }
         },
         "per_reporter_staleness_flat": [
             {
                 "reporter": "puptoo",
                 "last_check_in": "2019-01-10T08:07:03.354312Z",
+                "stale_timestamp": "2030-01-10T08:07:03.354307Z",
+                "check_in_succeeded": true
+            },
+            {
+                "reporter": "yupana",
+                "last_check_in": "2022-01-10T08:07:03.354312Z",
                 "stale_timestamp": "2030-01-10T08:07:03.354307Z",
                 "check_in_succeeded": true
             }

--- a/test/hosts.json
+++ b/test/hosts.json
@@ -321,8 +321,8 @@
         "per_reporter_staleness_flat": [
             {
                 "reporter": "puptoo",
-                "last_check_in":"2029-02-09T08:07:03.354307Z",
-                "stale_timestamp": "2029-02-10T08:07:03.354307Z",
+                "last_check_in": "2019-01-10T08:07:03.354312Z",
+                "stale_timestamp": "2030-01-10T08:07:03.354307Z",
                 "check_in_succeeded": true
             }
         ]

--- a/test/hosts.json
+++ b/test/hosts.json
@@ -164,7 +164,15 @@
                 "stale_timestamp": "2030-01-10T08:07:03.354307Z",
                 "check_in_succeeded": true
             }
-        }
+        },
+        "per_reporter_staleness_flat": [
+            {
+                "reporter": "puptoo",
+                "last_check_in": "2019-01-10T08:07:03.354312Z",
+                "stale_timestamp": "2030-01-10T08:07:03.354307Z",
+                "check_in_succeeded": true
+            }
+        ]
     },
     {
         "id": "6e7b6317-0a2d-4552-a2f2-b7da0aece49d",
@@ -309,7 +317,15 @@
                 "stale_timestamp": "2030-01-10T08:07:03.354307Z",
                 "check_in_succeeded": true
             }
-        }
+        },
+        "per_reporter_staleness_flat": [
+            {
+                "reporter": "yupana",
+                "last_check_in":"2029-02-09T08:07:03.354307Z",
+                "stale_timestamp": "2029-02-10T08:07:03.354307Z",
+                "check_in_succeeded": true
+            }
+        ]
     },
     {
         "id": "f5ac67e1-ad65-4b62-bc27-845cc6d4bcee",
@@ -457,11 +473,30 @@
         ],
         "per_reporter_staleness": {
             "puptoo": {
-                "last_check_in": "2019-01-10T08:07:03.354312Z",
-                "stale_timestamp": "2030-01-10T08:07:03.354307Z",
+                "last_check_in": "2019-03-09T08:07:03.354307Z",
+                "stale_timestamp": "2019-03-10T08:07:03.354307Z",
                 "check_in_succeeded": true
+            },
+            "yupana": {
+                "last_check_in": "2019-01-10T08:07:03.354307Z",
+                "stale_timestamp": "2019-01-11T08:07:03.354307Z",
+                "check_in_succeeded": false
             }
-        }
+        },
+        "per_reporter_staleness_flat": [
+            {
+                "reporter": "puptoo",
+                "last_check_in": "2019-03-09T08:07:03.354307Z",
+                "stale_timestamp": "2019-03-10T08:07:03.354307Z",
+                "check_in_succeeded": true
+            },
+            {
+                "reporter": "yupana",
+                "last_check_in": "2019-01-10T08:07:03.354307Z",
+                "stale_timestamp": "2019-01-11T08:07:03.354307Z",
+                "check_in_succeeded": false
+            }
+        ]
     },
     {
         "id": "f5ac67e1-ad65-4b62-bc27-845cc6d4bc01",
@@ -490,7 +525,15 @@
                 "stale_timestamp": "2030-01-10T08:07:03.354307Z",
                 "check_in_succeeded": true
             }
-        }
+        },
+        "per_reporter_staleness_flat": [
+            {
+                "reporter": "puptoo",
+                "last_check_in": "2019-01-10T08:07:03.354312Z",
+                "stale_timestamp": "2030-01-10T08:07:03.354307Z",
+                "check_in_succeeded": true
+            }
+        ]
     },
     {
         "id": "f5ac67e1-ad65-4b62-bc27-845cc6d4bc02",
@@ -542,7 +585,15 @@
                 "stale_timestamp": "2030-01-10T08:07:03.354307Z",
                 "check_in_succeeded": true
             }
-        }
+        },
+        "per_reporter_staleness_flat": [
+            {
+                "reporter": "puptoo",
+                "last_check_in": "2019-01-10T08:07:03.354312Z",
+                "stale_timestamp": "2030-01-10T08:07:03.354307Z",
+                "check_in_succeeded": true
+            }
+        ]
     },
     {
         "id": "f5ac67e1-ad65-4b62-bc27-845cc6d4bc04",
@@ -572,7 +623,15 @@
                 "stale_timestamp": "2030-01-10T08:07:03.354307Z",
                 "check_in_succeeded": true
             }
-        }
+        },
+        "per_reporter_staleness_flat": [
+            {
+                "reporter": "puptoo",
+                "last_check_in": "2019-01-10T08:07:03.354312Z",
+                "stale_timestamp": "2030-01-10T08:07:03.354307Z",
+                "check_in_succeeded": true
+            }
+        ]
     },
     {
         "id": "a5ac67e1-ad65-4b62-bc27-845cc6d4bcea",
@@ -614,7 +673,15 @@
                 "stale_timestamp": "2030-01-10T08:07:03.354307Z",
                 "check_in_succeeded": true
             }
-        }
+        },
+        "per_reporter_staleness_flat": [
+            {
+                "reporter": "puptoo",
+                "last_check_in": "2019-01-10T08:07:03.354312Z",
+                "stale_timestamp": "2030-01-10T08:07:03.354307Z",
+                "check_in_succeeded": true
+            }
+        ]
     },
     {
         "id": "a5ac67e1-ad65-4b62-bc27-845cc6d4bceb",
@@ -657,7 +724,15 @@
                 "stale_timestamp": "2030-01-10T08:07:03.354307Z",
                 "check_in_succeeded": true
             }
-        }
+        },
+        "per_reporter_staleness_flat": [
+            {
+                "reporter": "puptoo",
+                "last_check_in": "2019-01-10T08:07:03.354312Z",
+                "stale_timestamp": "2030-01-10T08:07:03.354307Z",
+                "check_in_succeeded": true
+            }
+        ]
     },
     {
         "id": "a5ac67e1-ad65-4b62-bc27-845cc6d4bcec",
@@ -698,7 +773,15 @@
                 "stale_timestamp": "2030-01-10T08:07:03.354307Z",
                 "check_in_succeeded": true
             }
-        }
+        },
+        "per_reporter_staleness_flat": [
+            {
+                "reporter": "puptoo",
+                "last_check_in": "2019-01-10T08:07:03.354312Z",
+                "stale_timestamp": "2030-01-10T08:07:03.354307Z",
+                "check_in_succeeded": true
+            }
+        ]
     },
     {
         "id": "a5ac67e1-ad65-4b62-bc27-845cc6d4bced",
@@ -739,7 +822,15 @@
                 "stale_timestamp": "2030-01-10T08:07:03.354307Z",
                 "check_in_succeeded": true
             }
-        }
+        },
+        "per_reporter_staleness_flat": [
+            {
+                "reporter": "puptoo",
+                "last_check_in": "2019-01-10T08:07:03.354312Z",
+                "stale_timestamp": "2030-01-10T08:07:03.354307Z",
+                "check_in_succeeded": true
+            }
+        ]
     },
     {
         "id": "a5ac67e1-ad65-4b62-bc27-845cc6d4bc69",
@@ -780,7 +871,15 @@
                 "stale_timestamp": "2030-01-10T08:07:03.354307Z",
                 "check_in_succeeded": true
             }
-        }
+        },
+        "per_reporter_staleness_flat": [
+            {
+                "reporter": "puptoo",
+                "last_check_in": "2019-01-10T08:07:03.354312Z",
+                "stale_timestamp": "2030-01-10T08:07:03.354307Z",
+                "check_in_succeeded": true
+            }
+        ]
     },
     {
         "id": "a5ac67e1-ad65-5c79-bc27-845cc6d4bc69",
@@ -821,7 +920,15 @@
                 "stale_timestamp": "2030-01-10T08:07:03.354307Z",
                 "check_in_succeeded": true
             }
-        }
+        },
+        "per_reporter_staleness_flat": [
+            {
+                "reporter": "puptoo",
+                "last_check_in": "2019-01-10T08:07:03.354312Z",
+                "stale_timestamp": "2030-01-10T08:07:03.354307Z",
+                "check_in_succeeded": true
+            }
+        ]
     },
     {
         "id": "6e7b6339-0a2d-4552-a2f2-b7da0aece49d",
@@ -883,7 +990,15 @@
                 "stale_timestamp": "2030-01-10T08:07:03.354307Z",
                 "check_in_succeeded": true
             }
-        }
+        },
+        "per_reporter_staleness_flat": [
+            {
+                "reporter": "puptoo",
+                "last_check_in": "2019-01-10T08:07:03.354312Z",
+                "stale_timestamp": "2030-01-10T08:07:03.354307Z",
+                "check_in_succeeded": true
+            }
+        ]
     },
     {
         "id": "6e7b6339-9y2d-4552-a2f2-b7da0aece49d",
@@ -945,7 +1060,15 @@
                 "stale_timestamp": "2030-01-10T08:07:03.354307Z",
                 "check_in_succeeded": true
             }
-        }
+        },
+        "per_reporter_staleness_flat": [
+            {
+                "reporter": "puptoo",
+                "last_check_in": "2019-01-10T08:07:03.354312Z",
+                "stale_timestamp": "2030-01-10T08:07:03.354307Z",
+                "check_in_succeeded": true
+            }
+        ]
     },
     {
         "id": "d1119a66-ffb7-4529-a8ca-15439aed29ad",
@@ -969,7 +1092,15 @@
                 "stale_timestamp": "2030-01-10T08:07:03.354307Z",
                 "check_in_succeeded": true
             }
-        }
+        },
+        "per_reporter_staleness_flat": [
+            {
+                "reporter": "puptoo",
+                "last_check_in": "2019-01-10T08:07:03.354312Z",
+                "stale_timestamp": "2030-01-10T08:07:03.354307Z",
+                "check_in_succeeded": true
+            }
+        ]
     },
     {
         "id": "5212d66b-62bf-49ee-8f96-dbb5d866fa2a",
@@ -1058,7 +1189,15 @@
                 "stale_timestamp": "2030-01-10T08:07:03.354307Z",
                 "check_in_succeeded": true
             }
-        }
+        },
+        "per_reporter_staleness_flat": [
+            {
+                "reporter": "puptoo",
+                "last_check_in": "2019-01-10T08:07:03.354312Z",
+                "stale_timestamp": "2030-01-10T08:07:03.354307Z",
+                "check_in_succeeded": true
+            }
+        ]
     },
     {
         "id": "f2fea2de-5dd5-4f32-a6c1-142c7affc321",
@@ -1132,7 +1271,15 @@
                 "stale_timestamp": "2030-01-10T08:07:03.354307Z",
                 "check_in_succeeded": true
             }
-        }
+        },
+        "per_reporter_staleness_flat": [
+            {
+                "reporter": "puptoo",
+                "last_check_in": "2019-01-10T08:07:03.354312Z",
+                "stale_timestamp": "2030-01-10T08:07:03.354307Z",
+                "check_in_succeeded": true
+            }
+        ]
     },
     {
         "id": "399886f1-fcb5-43d8-be70-f4bbdb02d4b0",
@@ -1164,7 +1311,15 @@
                 "stale_timestamp": "2030-01-10T08:07:03.354307Z",
                 "check_in_succeeded": true
             }
-        }
+        },
+        "per_reporter_staleness_flat": [
+            {
+                "reporter": "puptoo",
+                "last_check_in": "2019-01-10T08:07:03.354312Z",
+                "stale_timestamp": "2030-01-10T08:07:03.354307Z",
+                "check_in_succeeded": true
+            }
+        ]
     },
     {
         "id": "bd37baad-ce97-4488-ba0c-fb93edd36f7f",
@@ -1193,7 +1348,15 @@
                 "stale_timestamp": "2030-01-10T08:07:03.354307Z",
                 "check_in_succeeded": true
             }
-        }
+        },
+        "per_reporter_staleness_flat": [
+            {
+                "reporter": "puptoo",
+                "last_check_in": "2019-01-10T08:07:03.354312Z",
+                "stale_timestamp": "2030-01-10T08:07:03.354307Z",
+                "check_in_succeeded": true
+            }
+        ]
     },
     {
         "id": "b72cf877-3433-4755-b172-65700a56545a",
@@ -1237,6 +1400,14 @@
                 "stale_timestamp": "2030-01-10T08:07:03.354307Z",
                 "check_in_succeeded": true
             }
-        }
+        },
+        "per_reporter_staleness_flat": [
+            {
+                "reporter": "puptoo",
+                "last_check_in": "2019-01-10T08:07:03.354312Z",
+                "stale_timestamp": "2030-01-10T08:07:03.354307Z",
+                "check_in_succeeded": true
+            }
+        ]
     }
 ]

--- a/test/hosts.json
+++ b/test/hosts.json
@@ -320,7 +320,7 @@
         },
         "per_reporter_staleness_flat": [
             {
-                "reporter": "yupana",
+                "reporter": "puptoo",
                 "last_check_in":"2029-02-09T08:07:03.354307Z",
                 "stale_timestamp": "2029-02-10T08:07:03.354307Z",
                 "check_in_succeeded": true

--- a/test/mapping.json
+++ b/test/mapping.json
@@ -360,6 +360,40 @@
           "normalizer": "case_insensitive"
         }
       }
+    },
+    "per_reporter_staleness": {
+      "type": "object",
+      "properties": {
+        "reporter": {
+          "type": "keyword"
+        },
+        "last_check_in": {
+          "type": "date_nanos"
+        },
+        "stale_timestamp": {
+          "type": "date_nanos"
+        },
+        "check_in_succeeded": {
+          "type": "boolean"
+        }
+      }
+    },
+    "per_reporter_staleness_flat": {
+      "type": "nested",
+      "properties": {
+        "reporter": {
+          "type": "keyword"
+        },
+        "last_check_in": {
+          "type": "date_nanos"
+        },
+        "stale_timestamp": {
+          "type": "date_nanos"
+        },
+        "check_in_succeeded": {
+          "type": "boolean"
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
This follows up on #151. It adds `per_reporter_staleness` and `per_reporter_staleness_flat` to the schema, and filters on `per_reporter_staleness_flat` specifically. The intent is to get the regular object data in the response, while filtering on the flattened version like this:
```
filter: {
    per_reporter_staleness: {
        reporter: "yupana"
        stale_timestamp: {gte: "2020-02-10T08:07:03.354307Z"}
        last_check_in: {gte: "2020-02-09T08:07:03.354307Z"}
        check_in_succeeded: {is: true}
    }
}
```