### PR TITLE
[ESSNTL-2327] Limit max size of int values

### DIFF
--- a/inventory-schemas/system_profile_schema.yaml
+++ b/inventory-schemas/system_profile_schema.yaml
@@ -117,7 +117,7 @@ $defs:
         description: MTU (Maximum transmission unit)
         type: integer
         minimum: 0
-        maximum: 18446744073709551615
+        maximum: 2147483647
       mac_address:
         description: MAC address (with or without colons)
         example: "00:00:00:00:00:00, 10:00:00:00:00:00, 20:00:00:00:00:00"
@@ -212,20 +212,20 @@ $defs:
       number_of_cpus:
         type: integer
         minimum: 0
-        maximum: 4294967295
+        maximum: 2147483647
       number_of_sockets:
         type: integer
         minimum: 0
-        maximum: 4294967295
+        maximum: 2147483647
       cores_per_socket:
         type: integer
         minimum: 0
-        maximum: 4294967295
+        maximum: 2147483647
       system_memory_bytes:
         type: integer
         format: int64
         minimum: 0
-        maximum: 18446744073709551615
+        maximum: 9007199254740991
       infrastructure_type:
         type: string
         maxLength: 100


### PR DESCRIPTION
Large values yield a 500 error but should be beyond a logical size for the fields so adding a max value to each of the int and int64 fields should not impact customers yet should protect against the potential for these errors.

This accompanies the inventory-schemas PR to make related limit changes:
https://github.com/RedHatInsights/inventory-schemas/pull/92