### PR TITLE
Add new fields to ephemeral mapping

### DIFF
--- a/deploy/ephemeral.yaml
+++ b/deploy/ephemeral.yaml
@@ -462,6 +462,9 @@ objects:
                   "arch": {
                     "type": "keyword"
                   },
+                  "basearch": {
+                    "type": "keyword"
+                  },
                   "kernel_modules": {
                     "type": "keyword"
                   },
@@ -562,6 +565,9 @@ objects:
                   "greenboot_status": {
                     "type": "keyword"
                   },
+                  "releasever": {
+                    "type": "keyword"
+                  },
                   "greenboot_fallback_detected": {
                     "type": "boolean"
                   },
@@ -637,7 +643,15 @@ objects:
                         "type": "keyword"
                       }
                     }
-                  }
+                  },
+                  "sap": {
+                    "type": "object",
+                    "properties": {
+                      "sap_system": {
+                        "type": "boolean"
+                      }
+                    }
+                  },
                 }
               },
               "tags_structured": {


### PR DESCRIPTION
Adds the newest System Profile fields to the ephemeral index mapping. It seems that running `npm updateFromSchema` did not update `ephemeral.yaml` as it was supposed to. I'll investigate that next and follow up with a fix