### PR TITLE
RHCLOUD-23978 update xjoin-search image to use ubi8-minimal

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,6 +1,20 @@
-FROM registry.redhat.io/ubi8/nodejs-14
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 
 ARG BUILD_COMMIT=unknown
+
+# install packages from centos if not building on RHSM system
+RUN FULL_RHEL=$(microdnf repolist --enabled | grep rhel-8) ; \
+    if [ -z "$FULL_RHEL" ] ; then \
+        rpm -Uvh http://mirror.centos.org/centos/8-stream/BaseOS/x86_64/os/Packages/centos-stream-repos-8-4.el8.noarch.rpm \
+                 http://mirror.centos.org/centos/8-stream/BaseOS/x86_64/os/Packages/centos-gpg-keys-8-4.el8.noarch.rpm && \
+        sed -i 's/^\(enabled.*\)/\1\npriority=200/;' /etc/yum.repos.d/CentOS*.repo ; \
+    fi
+
+RUN microdnf module enable nodejs:14 && \
+    microdnf install --setopt=tsflags=nodocs -y nodejs git && \
+    microdnf install -y rsync tar procps-ng && \
+    microdnf upgrade -y && \
+    microdnf clean all
 
 WORKDIR /opt/app-root/src
 


### PR DESCRIPTION
This PR implements [RHCLOUD-23978](https://issues.redhat.com/browse/RHCLOUD-23978), which is a sub-task of [RHCLOUD-23856](https://issues.redhat.com/browse/RHCLOUD-23856)

