### PR TITLE
Run elasticsearch container before updating schema

### DIFF
--- a/.github/workflows/update_from_schema.yaml
+++ b/.github/workflows/update_from_schema.yaml
@@ -17,6 +17,11 @@ jobs:
     steps:
       - name: Check out xjoin-config
         uses: actions/checkout@v3
+      - name: Run docker-compose up elasticsearch
+        uses: isbang/compose-action@v1.4.1
+        with:
+          compose-file: "./docker-compose.yml"
+          services: elasticsearch
       - name: Check out schema repo to copy current schema from
         uses: actions/checkout@v3
         with:
@@ -38,6 +43,7 @@ jobs:
           cd scripts
           npm ci
           npm run updateFromSchema
+          npm run coverage -- -u
           git diff
           git add -u
           git commit -m "updated xjoin-search to support schema changes. SHA: ${{ steps.vars.outputs.schema_sha }}" || echo "No new changes"


### PR DESCRIPTION
To be able to update `xjoin-search` to support the latest `inventory-schemas`, we need to get an Elasticsearch container running.

This patch adds the usage of `isbang/compose-action` to run the command `docker-compose up elasticsearch`.

Example of run: https://github.com/RedHatInsights/xjoin-search/actions/runs/4702162573/jobs/8339098926