### PR TITLE
Add HBI committers to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,3 @@
 # Default owners
 *       @fijshion
+*       @RedHatInsights/host-based-inventory-committers


### PR DESCRIPTION
Adds the HBI committers team to the CODEOWNERS file so that we get added as reviewers to new PRs.