### PR TITLE
Remove xjoin-api-gateway dependency

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -14,8 +14,6 @@ objects:
       iqePlugin: xjoin
     dependencies:
       - host-inventory
-    optionalDependencies:
-      - xjoin-api-gateway
     deployments:
     - name: api
       minReplicas: ${{NUM_REPLICAS}}

--- a/deploy/ephemeral.yaml
+++ b/deploy/ephemeral.yaml
@@ -13,8 +13,6 @@ objects:
         iqePlugin: xjoin
       dependencies:
         - host-inventory
-      optionalDependencies:
-        - xjoin-api-gateway
       deployments:
         - name: api
           minReplicas: ${{NUM_REPLICAS}}


### PR DESCRIPTION
Removes the xjoin-api-gateway dependency from the clowdapp. xjoin-api-gateway was something made for v2; now that we are moving in a different direction, we need to remove this. Also, our builds are currently broken because we removed apicurio, which is needed for api-gateway.