### PR TITLE
[RHINENG-10134] Remove esrun package and esbuild (its indirect dependency)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,6 @@
       },
       "devDependencies": {
         "@ckyrouac/json-schema-to-es-mapping": "^0.3.7",
-        "@digitak/esrun": "^1.2.8",
         "@graphql-codegen/cli": "^2.13.8",
         "@graphql-codegen/introspection": "^2.2.1",
         "@graphql-codegen/typescript": "^2.8.0",
@@ -1427,30 +1426,6 @@
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
-    },
-    "node_modules/@digitak/esrun": {
-      "version": "1.2.19",
-      "resolved": "https://registry.npmjs.org/@digitak/esrun/-/esrun-1.2.19.tgz",
-      "integrity": "sha512-UlvTCOfEUP9yxF4zs0Pt3TW49evbTMk6VLWskRgVXexS/f6rixf4bk1cLuWKxgsvAiTpXFJ9VWYDzO6HQHVRTw==",
-      "dev": true,
-      "dependencies": {
-        "@digitak/grubber": "^2.0.4",
-        "anymatch": "^3.1.2",
-        "chokidar": "^3.5.1",
-        "esbuild": "^0.12.4"
-      },
-      "bin": {
-        "esrun": "library/bin.js"
-      },
-      "engines": {
-        "node": ">=14.0"
-      }
-    },
-    "node_modules/@digitak/grubber": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@digitak/grubber/-/grubber-2.0.6.tgz",
-      "integrity": "sha512-AgHOVhpkgTbJh4hzbqdjLgIxtHRgD89rCytyTLvsVix+qeaPcBFjQwpWU6/Aq/XBrLKlEMN6/D8QxYrgTe32DA==",
-      "dev": true
     },
     "node_modules/@elastic/elasticsearch": {
       "version": "7.13.0",
@@ -5752,16 +5727,6 @@
       "dev": true,
       "dependencies": {
         "is-arrayish": "^0.2.1"
-      }
-    },
-    "node_modules/esbuild": {
-      "version": "0.12.29",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.12.29.tgz",
-      "integrity": "sha512-w/XuoBCSwepyiZtIRsKsetiLDUVGPVw1E/R3VTFSecIy8UR7Cq3SOtwKHJMFoVqqVG36aGkzh4e8BvpO1Fdc7g==",
-      "dev": true,
-      "hasInstallScript": true,
-      "bin": {
-        "esbuild": "bin/esbuild"
       }
     },
     "node_modules/escalade": {
@@ -13172,24 +13137,6 @@
         }
       }
     },
-    "@digitak/esrun": {
-      "version": "1.2.19",
-      "resolved": "https://registry.npmjs.org/@digitak/esrun/-/esrun-1.2.19.tgz",
-      "integrity": "sha512-UlvTCOfEUP9yxF4zs0Pt3TW49evbTMk6VLWskRgVXexS/f6rixf4bk1cLuWKxgsvAiTpXFJ9VWYDzO6HQHVRTw==",
-      "dev": true,
-      "requires": {
-        "@digitak/grubber": "^2.0.4",
-        "anymatch": "^3.1.2",
-        "chokidar": "^3.5.1",
-        "esbuild": "^0.12.4"
-      }
-    },
-    "@digitak/grubber": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@digitak/grubber/-/grubber-2.0.6.tgz",
-      "integrity": "sha512-AgHOVhpkgTbJh4hzbqdjLgIxtHRgD89rCytyTLvsVix+qeaPcBFjQwpWU6/Aq/XBrLKlEMN6/D8QxYrgTe32DA==",
-      "dev": true
-    },
     "@elastic/elasticsearch": {
       "version": "7.13.0",
       "resolved": "https://registry.npmjs.org/@elastic/elasticsearch/-/elasticsearch-7.13.0.tgz",
@@ -16630,12 +16577,6 @@
       "requires": {
         "is-arrayish": "^0.2.1"
       }
-    },
-    "esbuild": {
-      "version": "0.12.29",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.12.29.tgz",
-      "integrity": "sha512-w/XuoBCSwepyiZtIRsKsetiLDUVGPVw1E/R3VTFSecIy8UR7Cq3SOtwKHJMFoVqqVG36aGkzh4e8BvpO1Fdc7g==",
-      "dev": true
     },
     "escalade": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
   "author": "Jozef Hartinger",
   "devDependencies": {
     "@ckyrouac/json-schema-to-es-mapping": "^0.3.7",
-    "@digitak/esrun": "^1.2.8",
     "@graphql-codegen/cli": "^2.13.8",
     "@graphql-codegen/introspection": "^2.2.1",
     "@graphql-codegen/typescript": "^2.8.0",


### PR DESCRIPTION
In order to fix a Go vulnerability issue caused by `esbuild` which is deliberately intended to be compatible with an old Go version[[1]](https://esbuild.github.io/faq/#old-go-version).

This patch removes `esrun` from development dependencies list. `esbuild` is coming from `esrun` as one of its own dependency, but it looks like we don't use it at all. So it is safe to remove these packages from `xjoin-search`.

[1] - https://esbuild.github.io/faq/#old-go-version