### PR TITLE
fix(CI): use jq in checkimage

### DIFF
--- a/.github/workflows/checkimage.yaml
+++ b/.github/workflows/checkimage.yaml
@@ -15,7 +15,7 @@ jobs:
       - name: Check change
         run: |
           base=$(grep -Po '(?<=FROM )(.*)' build/Dockerfile)
-          skopeo inspect "docker://$base" | grep -Po '(?<="Digest": ")([^"]+)' > .baseimagedigest
+          skopeo inspect "docker://$base" | jq .Digest --raw-output > .baseimagedigest
       - name: Do change if the digest changed
         run: |
           git config user.name 'Update-a-Bot'


### PR DESCRIPTION
Use jq to query for image digest to remove the need to rely on skopeo inspect output having json keys in particular order. RHINENG-13679